### PR TITLE
Update system.cc

### DIFF
--- a/main/license.cc
+++ b/main/license.cc
@@ -53,10 +53,8 @@
 #include <sys/ioctl.h>
 #endif
 
-extern "C"
-{
 #include "blowfish.h"
-}
+
 #include "data_file.hh"
 #include "license.hh"
 #include "license_hash.hh"

--- a/main/system.cc
+++ b/main/system.cc
@@ -763,6 +763,8 @@ int System::SetDataPath(const char* path)
     }
 
     int len = strlen(path);
+    if (len >= sizeof(str))
+    	len = sizeof(str)-1;
     while (len > 1)
     {
         if (path[len - 1] != '/')
@@ -770,9 +772,10 @@ int System::SetDataPath(const char* path)
         //path[len - 1] = '\0';
         --len;
     }
-    strncpy(str,path,len);
+    memcpy(str,path,len);
+    str[len] = 0;
     data_path.Set(str);
-    memset(str,256,0);
+    //memset(str,256,0);
 
     // Make sure all data directories in path are set up
     chmod(path, DIR_PERMISSIONS);


### PR DESCRIPTION
Deal with line that was commented out to avoid writing to const argument, making sure copied string is null terminated. Otherwise, get a failure at startup ("Can't find path /usr/viewtouch/dat<garbage>"). Also prevent buffer overflow and removed pointless memset.