### PR TITLE
Enable Out-Of-Box Fonts to work

### DIFF
--- a/term/term_view.cc
+++ b/term/term_view.cc
@@ -62,20 +62,20 @@ struct FontDataType
 
 static FontDataType FontData[] =
 {
-    {FONT_TIMES_20,    20, "-adobe-times-medium-r-normal--20-*-iso8859-15"},
-    {FONT_TIMES_24,    24, "-adobe-times-medium-r-normal--24-*-iso8859-15"},
-    {FONT_TIMES_34,    33, "-adobe-times-medium-r-normal--34-*-iso8859-15"},
-    {FONT_TIMES_20B,   20, "-adobe-times-bold-r-normal--20-*-iso8859-15"},
-    {FONT_TIMES_24B,   24, "-adobe-times-bold-r-normal--24-*-iso8859-15"},
-    {FONT_TIMES_34B,   33, "-adobe-times-bold-r-normal--34-*-iso8859-15"},
-    {FONT_TIMES_14,    14, "-adobe-times-medium-r-normal--14-*-iso8859-15"},
-    {FONT_TIMES_14B,   14, "-adobe-times-bold-r-normal--14-*-iso8859-15"},
-    {FONT_TIMES_18,    18, "-adobe-times-medium-r-normal--18-*-iso8859-15"},
-    {FONT_TIMES_18B,   18, "-adobe-times-bold-r-normal--18-*-iso8859-15"},
-    {FONT_COURIER_18,  18, "-adobe-courier-medium-r-normal--18-*-*-*-*-*-iso8859-15"},
-    {FONT_COURIER_18B, 18, "-adobe-courier-bold-r-normal--18-*-*-*-*-*-iso8859-15"},
-    {FONT_COURIER_20,  20, "-adobe-courier-medium-r-normal--20-*-*-*-*-*-iso8859-15"},
-    {FONT_COURIER_20B, 20, "-adobe-courier-bold-r-normal--20-*-*-*-*-*-iso8859-15"}
+    {FONT_TIMES_20,    20, "-adobe-times-medium-r-normal--20-*-iso8859-1*"},
+    {FONT_TIMES_24,    24, "-adobe-times-medium-r-normal--24-*-iso8859-1*"},
+    {FONT_TIMES_34,    33, "-adobe-times-medium-r-normal--34-*-iso8859-1*"},
+    {FONT_TIMES_20B,   20, "-adobe-times-bold-r-normal--20-*-iso8859-1*"},
+    {FONT_TIMES_24B,   24, "-adobe-times-bold-r-normal--24-*-iso8859-1*"},
+    {FONT_TIMES_34B,   33, "-adobe-times-bold-r-normal--34-*-iso8859-1*"},
+    {FONT_TIMES_14,    14, "-adobe-times-medium-r-normal--14-*-iso8859-1*"},
+    {FONT_TIMES_14B,   14, "-adobe-times-bold-r-normal--14-*-iso8859-1*"},
+    {FONT_TIMES_18,    18, "-adobe-times-medium-r-normal--18-*-iso8859-1*"},
+    {FONT_TIMES_18B,   18, "-adobe-times-bold-r-normal--18-*-iso8859-1*"},
+    {FONT_COURIER_18,  18, "-adobe-courier-medium-r-normal--18-*-*-*-*-*-iso8859-1*"},
+    {FONT_COURIER_18B, 18, "-adobe-courier-bold-r-normal--18-*-*-*-*-*-iso8859-1*"},
+    {FONT_COURIER_20,  20, "-adobe-courier-medium-r-normal--20-*-*-*-*-*-iso8859-1*"},
+    {FONT_COURIER_20B, 20, "-adobe-courier-bold-r-normal--20-*-*-*-*-*-iso8859-1*"}
 };
 
 struct PenDataType


### PR DESCRIPTION
On Debian Jessie (and possibly other distributions) this eliminates the need for the /usr/viewtouch/fonts/ directory, while still maintaining compatibility with the Android app.

The Android app still works just fine, but this change eliminates the need for the fonts directory.

My system, a fairly minimal install of Debian with only:

Debian Desktop Environment
LXDE
SSH
Base System Utils

and the packages installed in the "Building" wiki page has fonts that appear to have an identical name and functionality to the fonts included with ViewTouch, only difference is that ViewTouch expects the fonts to end with -15 while my system's fonts end in -1. This change enables both fonts to work.

I have tested this with the Android app connecting to my PC running ViewTouch, PC without the ViewTouch distributed fonts, and Android with the fonts included in the app.

If someone can test this to make sure that it doesn't break anything in a more complex setup, that would be awesome.