### PR TITLE
cmake: include GTK3 headers as system library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ set(LICENSE_SERVER "default_license_server" CACHE STRING "The license server to 
 
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(GTK3 REQUIRED gtk+-3.0)
-include_directories(${GTK3_INCLUDE_DIRS})
+include_directories(SYSTEM ${GTK3_INCLUDE_DIRS})
 link_directories(${GTK3_LIBRARY_DIRS})
 add_definitions(${GTK3_CFLAGS_OTHER})
 


### PR DESCRIPTION
declare the GTK3 header includes as system library. We can't fix those
warnings, so don't show them