### PR TITLE
Add Continuous Integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,65 @@
+sudo: required
+language: bash
+services:
+  - docker
+
+# define the build matrix
+env:
+  global:
+    - PROJECT_DIR: .
+    - TOOLCHAIN: default
+    - BUILD_PACKAGES: cmake
+    - RUN_TESTS: false
+
+matrix:
+  include:
+    # Linux {
+
+    #   Ubuntu 16.04
+    - os: linux
+      env: >
+        BUILD_FLAVOR=ubuntu
+        BUILD_RELEASE=xenial
+        BUILD_ARCH=amd64
+    - os: linux
+      env: >
+        BUILD_FLAVOR=ubuntu
+        BUILD_RELEASE=bionic
+        BUILD_ARCH=amd64
+    - os: linux
+      env: >
+        BUILD_FLAVOR=ubuntu
+        BUILD_RELEASE=bionic
+        BUILD_ARCH=amd64
+        TOOLCHAIN=gcc-cxx17
+
+    # Debian 8
+    - os: linux
+      env: >
+        BUILD_FLAVOR=debian
+        BUILD_RELEASE=stretch
+        BUILD_ARCH=amd64
+    # } // end Linux
+
+before_install:
+  # use the Dockerfile.<distro>.template file for building the image with sed magic
+  - |
+    sed \
+    -e "s/@BUILD_FLAVOR@/${BUILD_FLAVOR}/g" \
+    -e "s/@BUILD_RELEASE@/${BUILD_RELEASE}/g" \
+    -e "s/@BUILD_ARCH@/${BUILD_ARCH}/g" \
+    -e "s/@BUILD_PACKAGES@/${BUILD_PACKAGES}/g" \
+    ci/Dockerfile.$BUILD_FLAVOR.template | tee ci/Dockerfile.$BUILD_FLAVOR.$BUILD_RELEASE.$BUILD_ARCH
+  - docker build -f ci/Dockerfile.$BUILD_FLAVOR.$BUILD_RELEASE.$BUILD_ARCH -t glog-devel .
+
+script: |
+  # run the respective .travis.<distro>.sh script
+  docker run \
+  -e BUILD_FLAVOR="$BUILD_FLAVOR" \
+  -e BUILD_RELEASE="$BUILD_RELEASE" \
+  -e BUILD_ARCH="$BUILD_ARCH" \
+  -e PROJECT_DIR="$PROJECT_DIR" \
+  -e TOOLCHAIN="$TOOLCHAIN" \
+  -e RUN_TESTS="$RUN_TESTS" \
+  -it glog-devel ./ci/travis.$BUILD_FLAVOR.sh
+

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 ViewTouch
 =========
 
+[![Build Status](https://img.shields.io/travis/ViewTouch/viewtouch/master.svg?label=Travis)](https://travis-ci.org/ViewTouch/viewtouch/builds)
+
 [![Join the chat at https://gitter.im/ViewTouch/viewtouch](https://badges.gitter.im/ViewTouch/viewtouch.svg)](https://gitter.im/ViewTouch/viewtouch?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 ViewTouch is a registered trademark in the USA.
 

--- a/ci/Dockerfile.debian.template
+++ b/ci/Dockerfile.debian.template
@@ -1,0 +1,24 @@
+# Build Ubuntu image
+FROM @BUILD_ARCH@/@BUILD_FLAVOR@:@BUILD_RELEASE@
+
+# see https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#/run
+RUN apt-get update && \
+  apt-get install -y --no-install-recommends \
+  @BUILD_PACKAGES@ \
+  build-essential \
+  xorg-dev \
+  libmotif-dev \
+  libfreetype6-dev \
+  libgtk-3-dev \
+  cmake \
+  git \
+  xwit \
+  xfonts-base \
+  xfonts-75dpi \
+  xfonts-100dpi \
+  g++
+
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
+COPY . /usr/src/app

--- a/ci/Dockerfile.ubuntu.template
+++ b/ci/Dockerfile.ubuntu.template
@@ -1,0 +1,24 @@
+# Build Ubuntu image
+FROM @BUILD_ARCH@/@BUILD_FLAVOR@:@BUILD_RELEASE@
+
+# see https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#/run
+RUN apt-get update && \
+  apt-get install -y --no-install-recommends \
+  @BUILD_PACKAGES@ \
+  build-essential \
+  xorg-dev \
+  libmotif-dev \
+  libfreetype6-dev \
+  libgtk-3-dev \
+  cmake \
+  git \
+  xwit \
+  xfonts-base \
+  xfonts-75dpi \
+  xfonts-100dpi \
+  g++
+
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
+COPY . /usr/src/app

--- a/ci/toolchains/.gitignore
+++ b/ci/toolchains/.gitignore
@@ -1,0 +1,2 @@
+# allow toolchain files to be tracked by git
+!*.cmake

--- a/ci/toolchains/default.cmake
+++ b/ci/toolchains/default.cmake
@@ -1,0 +1,1 @@
+# dummy toolchain

--- a/ci/toolchains/gcc-cxx11.cmake
+++ b/ci/toolchains/gcc-cxx11.cmake
@@ -1,0 +1,13 @@
+# Sample toolchain file for building with gcc compiler
+#
+# Typical usage:
+#    *) cmake -H. -B_build -DCMAKE_TOOLCHAIN_FILE="${PWD}/toolchains/gcc.cmake"
+
+# set compiler
+set(CMAKE_C_COMPILER gcc)
+set(CMAKE_CXX_COMPILER g++)
+
+# set c++ standard
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)

--- a/ci/toolchains/gcc-cxx14.cmake
+++ b/ci/toolchains/gcc-cxx14.cmake
@@ -1,0 +1,13 @@
+# Sample toolchain file for building with gcc compiler
+#
+# Typical usage:
+#    *) cmake -H. -B_build -DCMAKE_TOOLCHAIN_FILE="${PWD}/toolchains/gcc.cmake"
+
+# set compiler
+set(CMAKE_C_COMPILER gcc)
+set(CMAKE_CXX_COMPILER g++)
+
+# set c++ standard
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)

--- a/ci/toolchains/gcc-cxx17.cmake
+++ b/ci/toolchains/gcc-cxx17.cmake
@@ -1,0 +1,13 @@
+# Sample toolchain file for building with gcc compiler
+#
+# Typical usage:
+#    *) cmake -H. -B_build -DCMAKE_TOOLCHAIN_FILE="${PWD}/toolchains/gcc.cmake"
+
+# set compiler
+set(CMAKE_C_COMPILER gcc)
+set(CMAKE_CXX_COMPILER g++)
+
+# set c++ standard
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)

--- a/ci/toolchains/gcc-cxx98.cmake
+++ b/ci/toolchains/gcc-cxx98.cmake
@@ -1,0 +1,13 @@
+# Sample toolchain file for building with gcc compiler
+#
+# Typical usage:
+#    *) cmake -H. -B_build -DCMAKE_TOOLCHAIN_FILE="${PWD}/toolchains/gcc.cmake"
+
+# set compiler
+set(CMAKE_C_COMPILER gcc)
+set(CMAKE_CXX_COMPILER g++)
+
+# set c++ standard
+set(CMAKE_CXX_STANDARD 98)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)

--- a/ci/toolchains/gcc-gnuxx11.cmake
+++ b/ci/toolchains/gcc-gnuxx11.cmake
@@ -1,0 +1,13 @@
+# Sample toolchain file for building with gcc compiler
+#
+# Typical usage:
+#    *) cmake -H. -B_build -DCMAKE_TOOLCHAIN_FILE="${PWD}/toolchains/gcc.cmake"
+
+# set compiler
+set(CMAKE_C_COMPILER gcc)
+set(CMAKE_CXX_COMPILER g++)
+
+# set c++ standard
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS ON)

--- a/ci/travis.debian.sh
+++ b/ci/travis.debian.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+set -x
+
+uname -a
+
+cmake -H. -B_build_${TOOLCHAIN} -DCMAKE_TOOLCHAIN_FILE="${PWD}/ci/toolchains/${TOOLCHAIN}.cmake"
+cmake --build _build_${TOOLCHAIN}
+
+if [ "$RUN_TESTS" = true ]; then
+	CTEST_OUTPUT_ON_FAILURE=1 cmake --build _build_${TOOLCHAIN} --target test
+fi
+
+

--- a/ci/travis.ubuntu.sh
+++ b/ci/travis.ubuntu.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+set -x
+
+uname -a
+
+cmake -H. -B_build_${TOOLCHAIN} -DCMAKE_TOOLCHAIN_FILE="${PWD}/ci/toolchains/${TOOLCHAIN}.cmake"
+cmake --build _build_${TOOLCHAIN}
+
+if [ "$RUN_TESTS" = true ]; then
+	CTEST_OUTPUT_ON_FAILURE=1 cmake --build _build_${TOOLCHAIN} --target test
+fi
+
+


### PR DESCRIPTION
use travis-ci to build viewtouch on Ubuntu and Debian
also adds a Build-Tag with the latest build status

travis-ci needs to be enabled for this to take an effect: https://github.com/ViewTouch/viewtouch/issues/23