### PR TITLE
cmake: fix CXX flag setting

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,10 +26,24 @@ include_directories(SYSTEM ${GTK3_INCLUDE_DIRS})
 link_directories(${GTK3_LIBRARY_DIRS})
 add_definitions(${GTK3_CFLAGS_OTHER})
 
-#set(CMAKE_CXX_FLAGS "-Wall")
 #set(CMAKE_VERBOSE_MAKEFILE ON)
-set(CMAKE_CXX_FLAGS_DEBUG "-DDEBUG")
-set(CMAKE_CXX_FLAGS "-Wall -Wno-unused -Wno-unused-result")
+
+# add macro define 'DEBUG' to debug build
+set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -DDEBUG")
+
+# enable various compiler warnings
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wsign-compare")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wshadow")
+# disable specific compiler warnings
+#set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused") # also disables other unused warnings
+#set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-result")
+#set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-variable")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-but-set-variable")
+#set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-format")
+#set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-format-truncation")
+#set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-format-overflow")
+
 include_directories(main)
 include_directories(zone)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})


### PR DESCRIPTION
- don't overwrite CXX flags, instead append new flags
- add shadowing and conversion warnings

this fixes starting the debugger and set breakpoints out of qtcreator. it seems that the `-g` flag was not set because the CMAKE_CXX_FLAGS_DEBUG was overwritten
https://stackoverflow.com/questions/5179202/gcc-g-what-will-happen#5179230