### PR TITLE
ci: set language to cpp

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: required
-language: bash
+language: cpp
 services:
   - docker
 


### PR DESCRIPTION
with this commit in the Language category for the CI jobs at travis there stands "C++" instead of "no language set"