### PR TITLE
zone: fix revenue report period cycling

### DIFF
--- a/zone/report_zone.cc
+++ b/zone/report_zone.cc
@@ -752,6 +752,10 @@ SignalResult ReportZone::Signal(Terminal *t, const genericChar* message)
     case 9:  // nextperiod
       	printf("report_zone : nextperiod\n");
         period_view = NextValue(period_view, ReportPeriodValue);
+        if (period_view == SP_NONE)
+        {
+            period_view = SP_DAY;
+        }
         Draw(t, 1);
         return SIGNAL_OKAY;
     case 10:  // sortby


### PR DESCRIPTION
for revenue report a period of SP_NONE is not handled, but is returned
after SP_YTD. Fixing it by cycling around to SP_DAY

@GeneMosher please test if this fix breaks other report functionality

fixes https://github.com/ViewTouch/viewtouch/issues/60