### PR TITLE
main: check start variable in Overlap calculation

### DIFF
--- a/main/labor.cc
+++ b/main/labor.cc
@@ -367,7 +367,7 @@ int WorkEntry::Overlap(TimeInfo &st, TimeInfo &et)
 {
     FnTrace("WorkEntry::Overlap()");
     TimeInfo s, e;
-    if (start > st)
+    if (start.IsSet() && start > st)
         s = start;
     else
         s = st;


### PR DESCRIPTION
apply the same check for start variable as for end variable