### PR TITLE
main: manager: fix double mention of short month

### DIFF
--- a/main/manager.cc
+++ b/main/manager.cc
@@ -103,7 +103,7 @@ const char* MonthName[] = { "January", "February", "March", "April",
                       "October", "November", "December", NULL};
 
 const char* ShortMonthName[] = { "Jan", "Feb", "Mar", "Apr", "May", "Jun", 
-                           "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec", NULL};
+                                 "Jul", "Aug", "Sep", "Oct", "Nov", "Dec", NULL};
 
 /*************************************************************
  * Terminal Type values


### PR DESCRIPTION
The month June was two times in the list of month shortnames

This fixes the clock on the start page