### PR TITLE
main: fix duplication of new menu item names

### DIFF
--- a/main/sales.cc
+++ b/main/sales.cc
@@ -820,7 +820,7 @@ int PrintItem(char* buffer, int qualifier, const char* item)
 std::string FilterName(const std::string &name)
 {
     FnTrace("FilterName()");
-    std::string str = name;
+    std::string str;
     str.reserve(name.size());
 
     bool space = false; // flag to shorten spaces to one digit


### PR DESCRIPTION
FilterName did make a copy of the original string before adding the new
string with reduced whitespaces