### PR TITLE
Str: fix Clear() to actually clear string data

### DIFF
--- a/utility.cc
+++ b/utility.cc
@@ -128,6 +128,7 @@ Str::~Str()
 int Str::Clear()
 {
     FnTrace("Str::Clear()");
+    data.clear();
     return 0;
 }
 


### PR DESCRIPTION
Fixes https://github.com/ViewTouch/viewtouch/issues/75

The "Saving ..." message was tried to be cleared, but the implementation
of Str::Clear() was empty, therefore nothing happened and the old
message stayed