### PR TITLE
main: manager: fix shutdown crash

### DIFF
--- a/main/manager.cc
+++ b/main/manager.cc
@@ -180,7 +180,7 @@ static FontDataType FontData[] =
     {FONT_COURIER_20B, 10, 20, "-adobe-courier-bold-r-normal--20-*-*-*-*-*-*-*"}
 };
 
-static int UpdateID = 0;   // update callback function id
+static XtIntervalId UpdateID = 0;   // update callback function id
 static int LastMin  = -1;
 static int LastHour = -1;
 static int LastMeal = -1;


### PR DESCRIPTION
UpdateID was an int, Xt timer is an unsigned long. If a timer with
values bigger than int-max is returned the XtRemoveTimeOut segfaults
during shutdown.