### PR TITLE
main: check: don't access printer when it is a nullptr

### DIFF
--- a/main/check.cc
+++ b/main/check.cc
@@ -1132,7 +1132,13 @@ int Check::PrintWorkOrder(Terminal *term, Report *report, int printer_id, int re
     {
         report->Mode(PRINT_LARGE);
         report->TextL(" ");
-        report->NewLine(printer->order_margin);
+        if (printer)
+        {
+            report->NewLine(printer->order_margin);
+        } else
+        {
+            report->NewLine();
+        }
     }
 
     if (employee && employee->training)


### PR DESCRIPTION
fix segfault on finishing an order if no printer is present