### PR TITLE
Fix input_fn type

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Removed
 
 ### Fixed
+- segfault because of `input_id` narrowing conversion
 
 
 ## [v19.02.1] - 2019-02-16

--- a/main/manager.cc
+++ b/main/manager.cc
@@ -2908,7 +2908,7 @@ unsigned long AddTimeOutFn(TimeOutFn fn, int timeint, void *client_data)
                            (XtPointer) client_data);
 }
 
-int AddInputFn(InputFn fn, int device_no, void *client_data)
+unsigned long AddInputFn(InputFn fn, int device_no, void *client_data)
 {
     FnTrace("AddInputFn()");
     return XtAppAddInput(App, device_no, (XtPointer) XtInputReadMask,
@@ -2929,7 +2929,7 @@ int RemoveTimeOutFn(unsigned long fn_id)
     return 0;
 }
 
-int RemoveInputFn(int fn_id)
+int RemoveInputFn(unsigned long fn_id)
 {
     FnTrace("RemoveInputFn()");
     if (fn_id > 0)

--- a/main/manager.hh
+++ b/main/manager.hh
@@ -151,8 +151,8 @@ unsigned long AddTimeOutFn(TimeOutFn fn, int time, void *client_data);
 int RemoveTimeOutFn(unsigned long fn_id);
 
 // Add/Remove input watching function
-int AddInputFn(InputFn fn, int device_no, void *client_data);
-int RemoveInputFn(int fn_id);
+unsigned long AddInputFn(InputFn fn, int device_no, void *client_data);
+int RemoveInputFn(unsigned long fn_id);
 
 // Add/Remove work function
 unsigned long AddWorkFn(WorkFn fn, void *client_data);

--- a/main/terminal.hh
+++ b/main/terminal.hh
@@ -385,7 +385,7 @@ public:
     CharQueue *buffer_in;
     CharQueue *buffer_out;
     int socket_no;
-    int input_id;
+    unsigned long input_id = 0;
     unsigned long redraw_id = 0;
     std::mutex redraw_id_mutex;
     int message_set;


### PR DESCRIPTION
`input_id` was an int, XtInputId is an unsigned long. If an input_id with
values bigger than int-max is returned the XtRemoveInput segfaults.