### PR TITLE
Fix failed report render

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 - segfault because of `input_id` narrowing conversion
 - unhandled exception when ConfFile doesn't exist
+- don't try to render reports that failed to load
 
 
 ## [v19.02.1] - 2019-02-16

--- a/main/report.cc
+++ b/main/report.cc
@@ -265,6 +265,11 @@ int Report::Render(Terminal *term, LayoutZone *lz, Flt header_size,
                    Flt footer_size, int p, int print, Flt spacing)
 {
     FnTrace("Report::Render()");
+    if (body_list.empty())
+    {
+        ReportError("ReportRender: can't render report with empty body");
+        return 1;
+    }
     auto get_line_count = [](const int &sum, const ReportEntry &re) -> int
     {
         return sum + re.new_lines;

--- a/zone/report_zone.cc
+++ b/zone/report_zone.cc
@@ -1246,7 +1246,10 @@ RenderResult ReadZone::Render(Terminal *t, int update_flag)
     {
         loaded = 1;
         report.Clear();
-        report.Load(filename.Value(), color[0]);
+        if (report.Load(filename.Value(), color[0]) != 0)
+        {
+            return RENDER_ERROR;
+        }
     }
 
     int hs = 0;
@@ -1256,8 +1259,13 @@ RenderResult ReadZone::Render(Terminal *t, int update_flag)
         hs = 1;
     }
 
-    report.Render(t, this, hs, 0, page, 0);
-    return RENDER_OKAY;
+    if(report.Render(t, this, hs, 0, page, 0) == 0)
+    {
+        return RENDER_OKAY;
+    } else
+    {
+        return RENDER_ERROR;
+    }
 }
 
 SignalResult ReadZone::Signal(Terminal *t, const char* message)


### PR DESCRIPTION
don't render reports that failed to load. This resulted in an empty body_list which was not handled by Report::Render. Be more careful on both sides

fixes https://github.com/ViewTouch/viewtouch/issues/89