### PR TITLE
main: manager: disable autoupdate

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Added
 
 ### Changed
+- disable auto updater of `vt_main`
 
 ### Removed
 

--- a/main/manager.cc
+++ b/main/manager.cc
@@ -137,7 +137,7 @@ static int          FontHeight[32];
 int                 LoaderSocket = 0;
 int                 OpenTermPort = 10001;
 int                 OpenTermSocket = -1;
-int                 autoupdate = 1;
+int                 autoupdate = 0;
 
 // run the user command on startup if it is available; after that,
 // we'll only run it when we get SIGUSR2.  The 2 here indicates


### PR DESCRIPTION
disable auto update as there is no file provided to download. Disabling
the updater gets rid of another unneeded warning during startup