### PR TITLE
Fix StringCompare

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - don't try to render reports that failed to load
 - loader logofile path can be something other than `/usr/viewtouch/graphics/logofile`
 - loader CSS deprecation warnings
+- regression in StringCompare, old behavior restored (fixes subcheck receipe printing)
 
 
 ## [v19.02.1] - 2019-02-16

--- a/utility.cc
+++ b/utility.cc
@@ -762,8 +762,10 @@ int DeleteFile(const genericChar* filename)
 int StringCompare(const std::string &str1, const std::string &str2)
 {
     FnTrace("StringCompare()");
-    const std::string str1_lower = StringToLower(str1);
-    const std::string str2_lower = StringToLower(str2);
+    size_t common_length = std::min(str1.size(), str2.size());
+    const std::string str1_lower = StringToLower(str1.substr(0, common_length));
+    const std::string str2_lower = StringToLower(str2.substr(0, common_length));
+
     return str1_lower.compare(str2_lower);
 }
 

--- a/utility.hh
+++ b/utility.hh
@@ -200,6 +200,8 @@ extern int ReportError(const std::string &message);
 // (the prototype is here but the implementation isn't in utility.cc)
 // implementation is in main/manager.cc
 
+// compare same-length part of string
+// for example StringCompare("ab", "abcd")==0
 int StringCompare(const std::string &str1, const std::string &str2);
 // Case insesitive string compare
 int StringInString(const genericChar* haystack, const genericChar* needle);


### PR DESCRIPTION
the original utility::StringCompare function compared only the same
length part of the string. I did not reimplement the functionality
right and compared the full strings

old behavior:
StringCompare("print subcheck", "print") == 0 (it compares equals)

my wrongly implemented behavor:
std::string("print subcheck") .compare(std::string("print")) == 1
(not comparing equal)