### PR TITLE
Print receipt in training mode

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Changed
 - disable auto updater of `vt_main`
+- print finalized check receipe also in training mode
 
 ### Removed
 

--- a/zone/payment_zone.cc
+++ b/zone/payment_zone.cc
@@ -1046,7 +1046,7 @@ int PaymentZone::CloseCheck(Terminal *term, int force)
         // Update drawer record
         drawer_open = 0;
         Printer *pr = term->FindPrinter(PRINTER_RECEIPT);
-        if (pr && !currCheck->IsTraining() && (settings->receipt_print & RECEIPT_FINALIZE))
+        if (pr && (settings->receipt_print & RECEIPT_FINALIZE))
         {
             if (settings->cash_receipt || subCheck->OnlyCredit() == 0)
             {


### PR DESCRIPTION
in training mode the receipt when finalizing a payment was not printed. Do we want it to be printed even in training mode or is this behavior intended?