### PR TITLE
handle missing dat folder and add install target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -287,7 +287,11 @@ install(PROGRAMS 	scripts/vtrestart
 			scripts/runonce
 	DESTINATION viewtouch/bin
 )
-install(DIRECTORY dat DESTINATION viewtouch)
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/dat" AND IS_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/dat")
+    install(DIRECTORY dat DESTINATION viewtouch)
+else()
+    message(STATUS "'dat' folder is missing in source directory, excluding it from install target. You can get the bootstrap files from http://www.viewtouch.com/vt_data.html")
+endif()
 install(DIRECTORY graphics DESTINATION viewtouch)
 install(DIRECTORY css DESTINATION viewtouch)
 install(PROGRAMS scripts/vtcommands.pl DESTINATION viewtouch/bin/vtcommands)

--- a/ci/travis.sh
+++ b/ci/travis.sh
@@ -4,8 +4,9 @@ set -x
 
 uname -a
 
-cmake -H. -B_build_${TOOLCHAIN} -DCMAKE_TOOLCHAIN_FILE="${PWD}/ci/toolchains/${TOOLCHAIN}.cmake"
+cmake -H. -B_build_${TOOLCHAIN} -DCMAKE_TOOLCHAIN_FILE="${PWD}/ci/toolchains/${TOOLCHAIN}.cmake" -DCMAKE_INSTALL_PREFIX="${PWD}/_install_${TOOLCHAIN}"
 cmake --build _build_${TOOLCHAIN}
+cmake --build _build_${TOOLCHAIN} --target install
 
 if [ "$RUN_TESTS" = true ]; then
 	CTEST_OUTPUT_ON_FAILURE=1 cmake --build _build_${TOOLCHAIN} --target test


### PR DESCRIPTION
test install target because `dat` folder is missing in source, which breaks the install target
https://github.com/ViewTouch/viewtouch/issues/101

don't yet merge, I need to first fix the `CMakeLists.txt` entry to detect the `dat` folder and handle the case it is missing