### PR TITLE
main: report: Handle nullptr const char ptr in Report::Text again

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Removed
 
 ### Fixed
+- fix double line after header in some report tables #115
 
 
 ## [v21.01.1] - 2021-01-06

--- a/main/report.hh
+++ b/main/report.hh
@@ -96,8 +96,10 @@ public:
     Uchar align;
     Uchar edge;
     Uchar mode;
+    bool draw_a_line=false; // draw a line if text char ptr is a nullptr
 
     // Constructor
+    ReportEntry(const char *t, int c, int a, int m);
     ReportEntry(const std::string &t, int c, int a, int m);
     // Destructor
     ~ReportEntry() {}
@@ -146,6 +148,7 @@ public:
     int  Clear();                     // erases report
     int  Load(const std::string &textfile, int color = COLOR_DEFAULT);        // make report out of text file
     int  Mode(int flags);             // printing mode to use for next entries
+    int  Text(const char *t, int c, int a, float indent); // Adds text entry
     int  Text(const std::string &t, int c, int a, float indent); // Adds text entry
     int  Text2Col(const std::string &text, int color, int align, float indent);
     int  Number(int n, int c, int a, float indent); // Adds number entry

--- a/tests/main/CMakeLists.txt
+++ b/tests/main/CMakeLists.txt
@@ -9,7 +9,8 @@ endif()
 # create test
 add_executable(test_main
     test_main.cc
-    test_labor.cc)
+    test_labor.cc
+    test_report.cc)
 add_test(test_main test_main)
 target_link_libraries(test_main PRIVATE
     vtcore tz)

--- a/tests/main/test_report.cc
+++ b/tests/main/test_report.cc
@@ -1,0 +1,96 @@
+#include "catch2/catch.hpp"
+#include "report.hh"
+
+#include <string>
+#include <vector>
+#include <fstream>
+#include <limits> // std::numeric_limits
+#include <cmath> // std::isnan, std::isinf
+#include <locale>
+
+TEST_CASE("report: ReportEntry: pass nullptr for text sets draw_a_line")
+{
+    int color = 0;
+    int align = 0;
+    int mode = 0;
+    ReportEntry re(nullptr,color, align, mode);
+    CHECK(re.text.empty());
+    CHECK(re.draw_a_line == true);
+    CHECK(re.color == color);
+    CHECK(re.align == align);
+    CHECK(re.mode  == mode);
+}
+TEST_CASE("report: ReportEntry: pass char nullptr as text sets draw_line")
+{
+    const char *text = nullptr;
+    int color = 0;
+    int align = 0;
+    int mode = 0;
+    REQUIRE_NOTHROW(ReportEntry(text, color, align, mode));
+    ReportEntry re(text,color, align, mode);
+    CHECK(re.text.empty());
+    CHECK(re.draw_a_line == true);
+    CHECK(re.color == color);
+    CHECK(re.align == align);
+    CHECK(re.mode  == mode);
+}
+
+TEST_CASE("report: ReportEntry: empty char string does not set draw_a_line")
+{
+    const char *text = "";
+    int color = 0;
+    int align = 0;
+    int mode = 0;
+    REQUIRE_NOTHROW(ReportEntry(text, color, align, mode));
+    ReportEntry re(text,color, align, mode);
+    CHECK(re.text.empty());
+    CHECK(re.draw_a_line == false);
+}
+TEST_CASE("report: ReportEntry: empty std::string does not set draw_a_line")
+{
+    const std::string text = "";
+    int color = 0;
+    int align = 0;
+    int mode = 0;
+    REQUIRE_NOTHROW(ReportEntry(text, color, align, mode));
+    ReportEntry re(text,color, align, mode);
+    CHECK(re.text.empty());
+    CHECK(re.draw_a_line == false);
+}
+
+TEST_CASE("report: ReportEntry: char entries creating no line")
+{
+    auto text = GENERATE(as<const char *>{},
+        "a",
+        "12",
+        "11144",
+        "loads of text with spaces",
+        "nothing to see here!");
+    int color = 0;
+    int align = 0;
+    int mode = 0;
+    ReportEntry re(text,color, align, mode);
+    CHECK(re.text.empty() == false);
+    CHECK(re.draw_a_line == false);
+    CHECK(re.color == color);
+    CHECK(re.align == align);
+    CHECK(re.mode  == mode);
+}
+TEST_CASE("report: ReportEntry: std::string entries creating no line")
+{
+    auto text = GENERATE(as<std::string>{},
+        "a",
+        "12",
+        "11144",
+        "loads of text with spaces",
+        "nothing to see here!");
+    int color = 0;
+    int align = 0;
+    int mode = 0;
+    ReportEntry re(text,color, align, mode);
+    CHECK(re.text.empty() == false);
+    CHECK(re.draw_a_line == false);
+    CHECK(re.color == color);
+    CHECK(re.align == align);
+    CHECK(re.mode  == mode);
+}


### PR DESCRIPTION
In 9f10c00e461f6b86c8f9c2f9c058698df228efc7 main: report: remove custom DList, updates
the `Report::Text` function was switched to accept `std::string&` instead
of `const char*`. In the conversion the possibility of the char ptr to
be a nullptr was forgotten. A nullptr for text is interpreted as
`draw_a_line`. As `std::string` has no distinction between nullptr and
an empty string introduce the variable `bool draw_a_line` and
reintroduce the `const char*` overloads for `Report::Text` and
`ReportEntry()`.

Add tests to check ReportEntry constructors with `const char *` and
`std::string`. Especially the new behavior when `nullptr` is passed as
text, which should be the only instance `draw_a_line` should be set to
true.

fixes: https://github.com/ViewTouch/viewtouch/issues/115