### PR TITLE
main/locale: remove FamilyName NULL reference on Page 13 of 16

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Fixed
 - fix double line after header in some report tables #115
+- fix Segfault in Page 13 of 16 in "Customize Job Title, Families, Phrases" #117
 
 
 ## [v21.01.1] - 2021-01-06

--- a/main/locale.cc
+++ b/main/locale.cc
@@ -240,7 +240,6 @@ PhraseEntry PhraseData[] = {
     {12, FamilyName[28]},
     {12, FamilyName[29]},
     {12, FamilyName[30]},
-    {12, FamilyName[31]},
 
     {13, "Pre-Authorize"},
     {13, "Authorize"},


### PR DESCRIPTION
Page 13 of 16 (page index 12) has a reference to FamilyName[31], which
is a char* pointer initialized with `NULL`. When this `nullptr` is
passed to `Str::Set(const char *)` this results in a Segmentation fault.

Fixes Second Segfault of: https://github.com/ViewTouch/viewtouch/issues/117