### PR TITLE
CI: move from deprecated ubuntu-20.04 to ubuntu-24.04 image

### DIFF
--- a/.github/workflows/linux-simple-builds.yml
+++ b/.github/workflows/linux-simple-builds.yml
@@ -5,60 +5,48 @@ on: [push, pull_request]
 jobs:
   build:
     name: ${{matrix.cxx}}, C++${{matrix.std}}, ${{matrix.build_type}}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         cxx:
-          - g++-8
-          - g++-9
-          - g++-10
-          - g++-11
-          - clang++-6.0
-          - clang++-7
-          - clang++-8
-          - clang++-9
-          - clang++-10
+          - g++-12
+          - g++-13
+          - g++-14
+          - clang++-16
+          - clang++-17
+          - clang++-18
         build_type: [Debug] #, Release]
         std: [17]
         include:
-        # cannot be installed on ubuntu-20.04 be default?
-          - cxx: g++-8
-            cc: gcc-8
-            other_pkgs: g++-8
-          - cxx: g++-9
-            cc: gcc-9
-            other_pkgs: g++-9
-          - cxx: g++-10
-            cc: gcc-10
-            other_pkgs: g++-10
-          - cxx: g++-11
-            cc: gcc-11
-            other_pkgs: g++-11
-          - cxx: clang++-6.0
-            cc: clang-6.0
-            other_pkgs: clang-6.0
-          - cxx: clang++-7
-            cc: clang-7
-            other_pkgs: clang-7
-          - cxx: clang++-8
-            cc: clang-8
-            other_pkgs: clang-8
-          - cxx: clang++-9
-            cc: clang-9
-            other_pkgs: clang-9
-          - cxx: clang++-10
-            cc: clang-10
-            other_pkgs: clang-10
-          # GCC 10 + C++20
-          - cxx: g++-10
-            cc: gcc-10
-            other_pkgs: g++-10
+        # cannot be installed on ubuntu-24.04 be default?
+          - cxx: g++-12
+            cc: gcc-12
+            other_pkgs: g++-12
+          - cxx: g++-13
+            cc: gcc-13
+            other_pkgs: g++-13
+          - cxx: g++-14
+            cc: gcc-14
+            other_pkgs: g++-14
+          - cxx: clang++-16
+            cc: clang-16
+            other_pkgs: clang-16
+          - cxx: clang++-17
+            cc: clang-17
+            other_pkgs: clang-17
+          - cxx: clang++-18
+            cc: clang-18
+            other_pkgs: clang-18
+          # GCC 18 + C++20
+          - cxx: g++-18
+            cc: gcc-18
+            other_pkgs: g++-18
             std: 20
             build_type: Debug
-          # Clang 10 + C++20
-          - cxx: clang++-10
-            cc: clang-10
-            other_pkgs: clang-10
+          # Clang 18 + C++20
+          - cxx: clang++-18
+            cc: clang-18
+            other_pkgs: clang-18
             std: 20
             build_type: Debug
 
@@ -95,7 +83,7 @@ jobs:
       # Note: $GITHUB_WORKSPACE is distinct from ${{runner.workspace}}.
       #       This is important
       run: |
-        cmake -H$GITHUB_WORKSPACE -B_build_${{matrix.cxx}}_${{matrix.std}} \
+        cmake -S $GITHUB_WORKSPACE -B _build_${{matrix.cxx}}_${{matrix.std}} \
           -DCMAKE_INSTALL_PREFIX="${PWD}/_install_${{matrix.cxx}}_${{matrix.std}}" \
           -DCMAKE_BUILD_TYPE="${{matrix.build_type}}" \
           -DCMAKE_CXX_STANDARD=${{matrix.std}} \


### PR DESCRIPTION
The Ubuntu 20.04 images are deprected and removed on April 1st 2025. Move to the current latest LTS images Ubuntu 24.04.

Also update the available compilers to the ones listed in https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md#language-and-runtime

Fixes: https://github.com/ViewTouch/viewtouch/issues/143