### PR TITLE
Update vt_data download url from http to https

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -299,7 +299,7 @@ install(PROGRAMS 	scripts/vtrestart
 if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/dat" AND IS_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/dat")
     install(DIRECTORY dat DESTINATION viewtouch)
 else()
-    message(STATUS "'dat' folder is missing in source directory, excluding it from install target. You can get the bootstrap files from http://www.viewtouch.com/vt_data.html")
+    message(STATUS "'dat' folder is missing in source directory, excluding it from install target. You can get the bootstrap files from https://www.viewtouch.com/vt_data.html")
 endif()
 install(PROGRAMS scripts/vtcommands.pl DESTINATION viewtouch/bin/vtcommands)
 

--- a/main/manager.cc
+++ b/main/manager.cc
@@ -1238,7 +1238,7 @@ int FindVTData(InputDataFile *infile)
         return version;
 
     // download to official location and then try to read again
-    const std::string vtdata_url = "http://www.viewtouch.com/vt_data";
+    const std::string vtdata_url = "https://www.viewtouch.com/vt_data";
     fprintf(stderr, "Trying download VT_DATA: %s from '%s'\n", SYSTEM_DATA_FILE, vtdata_url.c_str());
     DownloadFile(vtdata_url, SYSTEM_DATA_FILE);
     if (infile->Open(SYSTEM_DATA_FILE, version) == 0)


### PR DESCRIPTION
Otherwise `curlcpp` downloads an html redirect page looking as follows:

```html
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>301 Moved Permanently</title>
</head><body>
<h1>Moved Permanently</h1>
<p>The document has moved <a href="https://viewtouch.com/vt_data">here</a>.</p>
</body></html>
```

and we get error messages when starting `vtpos`

```
Trying VT_DATA: /usr/viewtouch/dat/vt_data
Unable to read non existing file: '/usr/viewtouch/dat/vt_data'
Trying download VT_DATA: /usr/viewtouch/bin/vt_data from 'http://www.viewtouch.com/vt_data'
Successfully downloaded file '/usr/viewtouch/bin/vt_data' from 'http://www.viewtouch.com/vt_data'
Unknown file format for file: '/usr/viewtouch/bin/vt_data'
Unable to find vt_data file!!!
```