### PR TITLE
time_info: fix Set(string) parsing add unittest, C++20 compatibility

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 - fix configure step by searching for `PkgConfig` before using `pkg_check_module` #128
 - update embedded `catch.hpp` to `v2.13.10` to fix compilation on Ubuntu 20.04 and newer #131
+- fix `TimeInfo.Set(date_string)` function fixing `RunReport` `to`/`from` fields and C++20 compatibility #145
 
 
 ## [v21.05.1] - 2021-05-18

--- a/main/manager.cc
+++ b/main/manager.cc
@@ -2837,15 +2837,15 @@ int RunReport(const genericChar* report_string, Printer *printer)
     static Report *report = NULL;
     genericChar report_name[STRLONG] = "";
     genericChar report_from[STRLONG] = "";
-    TimeInfo from;
     genericChar report_to[STRLONG] = "";
-    TimeInfo to;
     int idx = 0;
     Terminal *term = MasterControl->TermList();
     System *system_data = term->system_data;
 
     if (report == NULL && report_string != NULL)
     {
+        TimeInfo from;
+        TimeInfo to;
         report = new Report;
 
         report->Clear();

--- a/tests/time_info/test_time_info.cc
+++ b/tests/time_info/test_time_info.cc
@@ -611,3 +611,29 @@ TEST_CASE("unset value for TimeInfo::Year() is not 0", "[time_info][Year]")
     CHECK(!ti.IsSet());
     CHECK(ti.Year() != 0);
 }
+
+TEST_CASE("check set time_info from string works two digit year YY", "[time_info][Set(string_2)][YY]")
+{
+    // "DD/MM/YY,HH:MM"   in 24hour format
+    TimeInfo ti;
+    ti.Set("12/03/25,15:16");
+    REQUIRE(ti.IsSet());
+    CHECK(ti.Day() == 12);
+    CHECK(ti.Month() == 3);
+    CHECK(ti.Year() == 2025);
+    CHECK(ti.Hour() == 15);
+    CHECK(ti.Min() == 16);
+}
+
+TEST_CASE("check set time_info from string works YYYY", "[time_info][Set(string)][YYYY]")
+{
+    // "DD/MM/YYYY,HH:MM" in 24hour format
+    TimeInfo ti;
+    ti.Set("12/03/2025,15:16");
+    REQUIRE(ti.IsSet());
+    CHECK(ti.Day() == 12);
+    CHECK(ti.Month() == 3);
+    CHECK(ti.Year() == 2025);
+    CHECK(ti.Hour() == 15);
+    CHECK(ti.Min() == 16);
+}

--- a/time_info.cc
+++ b/time_info.cc
@@ -86,7 +86,7 @@ int TimeInfo::Set(int s, int y)
 }
 
 /****
- * Set:  Parses date strings.  Acceptible formats:
+ * Set:  Parses date strings.  Acceptable formats:
  *   "DD/MM/YY,HH:MM"   in 24hour format
  *   "DD/MM/YYYY,HH:MM" in 24hour format
  *  Returns 1 on error, 0 on success.
@@ -97,12 +97,12 @@ int TimeInfo::Set(const std::string &date_string)
     using namespace date;
 
     std::istringstream ss(date_string);
-    sys_time<std::chrono::milliseconds> t;
-    ss >> date::parse("%d/%m/%y,%h:%m", t);
+    ss >> date::parse("%d/%m/%y,%H:%M", t_);
     if (ss.fail())
     {
-        ss >> date::parse("%d/%m/%Y,%h:%m", t);
-        if (ss.fail())
+        std::istringstream ss2(date_string);
+        ss2 >> date::parse("%d/%m/%Y,%H:%M", t_);
+        if (ss2.fail())
         {
             Clear();
             return false;


### PR DESCRIPTION
The format string passed to `date::parse()` was wrong, and thus never succeeded to parse a date string. Fix it such that the date is actually parsed.

And then actually use the parsed date info for TimeInfo. Previously it was parsed, but never stored in the class.

This also fixes gcc-14 C++20 compatibility.

Affected code is in `manager.cc` the function `RunReport()`

```cpp
        // need to pull out "Report From To"
        // date will be in the format "DD/MM/YY,HH:MM" in 24hour format
        if (NextToken(report_name, report_string, ' ', &idx))
        {
            if (NextToken(report_from, report_string, ' ', &idx))
            {
                from.Set(report_from);
                if (NextToken(report_to, report_string, ' ', &idx))
                    to.Set(report_to);
            }
        }
        if (!from.IsSet())
        {  // set date to yesterday morning, 00:00
            from.Set();
            from -= date::days(1);
            from.Floor<date::days>();
        }
        if (!to.IsSet())
        {  // set date to last night, 23:59
            to.Set();
            to.Floor<date::days>();
            to -= std::chrono::seconds(1);
        }
```

So the date was always from yesterday morning to last night.

Add unittest to check this function in the future.

Fixes: https://github.com/ViewTouch/viewtouch/issues/145