### PR TITLE
manager.cc: fix download URLs for bootstrap dat files

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -17,6 +17,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - update embedded `catch.hpp` to `v2.13.10` to fix compilation on Ubuntu 20.04 and newer #131
 - fix `TimeInfo.Set(date_string)` function fixing `RunReport` `to`/`from` fields and C++20 compatibility #145
 - update embedded `date` to `v3.0.4` and fix CMake 4+ compatibility #155
+- update download URLs from `http` to `https`, otherwise redirect html is downloaded
+  - `viewouch/bin/vt_data`     from https://www.viewtouch.com/vt_data #151
+  - `viewouch/dat/tables.dat`  from https://www.viewtouch.com/tables.dat #159
+  - `viewouch/dat/menu.dat`    from https://www.viewtouch.com/menu.dat #159
+  - `viewouch/dat/zone_db.dat` from https://www.viewtouch.com/zone_db.dat #159
 
 
 ## [v21.05.1] - 2021-05-18

--- a/main/manager.cc
+++ b/main/manager.cc
@@ -223,7 +223,7 @@ static int LastDay  = -1;
 #define VIEWTOUCH_UPDATE_COMMAND "/tmp/vt-update"
 // command to download script; -nv=not verbose, -T=timeout seconds, -t=# tries, -O=output
 #define VIEWTOUCH_UPDATE_REQUEST \
-    "wget -nv -T 2 -t 2 http://www.viewtouch.com/vt_updates/vt-update -O " VIEWTOUCH_UPDATE_COMMAND
+    "wget -nv -T 2 -t 2 https://www.viewtouch.com/vt_updates/vt-update -O " VIEWTOUCH_UPDATE_COMMAND
 
 static const std::string VIEWTOUCH_CONFIG = VIEWTOUCH_PATH "/dat/.viewtouch_config";
 
@@ -812,7 +812,7 @@ int StartSystem(int my_use_net)
     sys->FullPath(MASTER_MENU_DB, str);
     if (!fs::exists(str))
     {
-        const std::string menu_url = "http://www.viewtouch.com/menu.dat";
+        const std::string menu_url = "https://www.viewtouch.com/menu.dat";
         DownloadFile(menu_url, str);
     }
     if (sys->menu.Load(str))
@@ -1321,7 +1321,7 @@ int LoadSystemData()
     const char *filename1 = tables_filepath.c_str();
     if (!fs::exists(tables_filepath))
     {
-        const std::string tables_url = "http://www.viewtouch.com/tables.dat";
+        const std::string tables_url = "https://www.viewtouch.com/tables.dat";
         DownloadFile(tables_url, tables_filepath);
     }
 
@@ -1337,7 +1337,7 @@ int LoadSystemData()
     const char *filename2 = zone_db_filepath.c_str();
     if (!fs::exists(zone_db_filepath))
     {
-        const std::string zone_db_url = "http://www.viewtouch.com/zone_db.dat";
+        const std::string zone_db_url = "https://www.viewtouch.com/zone_db.dat";
         DownloadFile(zone_db_url, zone_db_filepath);
     }
     if (zone_db->Load(filename2))

--- a/tests/main/manager_stub.cc
+++ b/tests/main/manager_stub.cc
@@ -210,7 +210,7 @@ static int LastDay  = -1;
 #define VIEWTOUCH_UPDATE_COMMAND "/tmp/vt-update"
 // command to download script; -nv=not verbose, -T=timeout seconds, -t=# tries, -O=output
 #define VIEWTOUCH_UPDATE_REQUEST \
-    "wget -nv -T 2 -t 2 http://www.viewtouch.com/vt_updates/vt-update -O " VIEWTOUCH_UPDATE_COMMAND
+    "wget -nv -T 2 -t 2 https//www.viewtouch.com/vt_updates/vt-update -O " VIEWTOUCH_UPDATE_COMMAND
 
 static const std::string VIEWTOUCH_CONFIG = VIEWTOUCH_PATH "/dat/.viewtouch_config";
 


### PR DESCRIPTION
First found for `vt_data` and fixed with
https://github.com/ViewTouch/viewtouch/pull/151

Fixing `tables.dat`, `menu.dat` and `zone_db.dat` URLs as well.