### PR TITLE
cmake: fix deprecation warning, CMake 4.0+ compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5.1)
+cmake_minimum_required(VERSION 3.25.1...3.31.6)
 
 project(ViewTouch)
 message(STATUS "CMake version ${CMAKE_VERSION}")

--- a/changelog.md
+++ b/changelog.md
@@ -25,6 +25,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
   - `viewouch/dat/menu.dat`    from https://www.viewtouch.com/menu.dat #159
   - `viewouch/dat/zone_db.dat` from https://www.viewtouch.com/zone_db.dat #159
 - fix CMake warning about deprecated `exec_program()` and replace with `execute_process()` #154
+- fix CMake < 3.10 deprecation warning, require CMake 3.25.1 at least #156
 
 
 ## [v21.05.1] - 2021-05-18


### PR DESCRIPTION
Require a CMake 3.25.1 minimum version (version used by Debian 12 bookworm).

This fixes a CMake error when configuring with CMake 4.0+:
```
CMake Error at external/date/CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.

  Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
```

Fixes: https://github.com/ViewTouch/viewtouch/issues/156