### PR TITLE
Complete C++17 modernization and critical directory permissions fix

### DIFF
--- a/basic.hh
+++ b/basic.hh
@@ -1,7 +1,5 @@
-#pragma once
-
 /*
- * Copyright ViewTouch, Inc., 1995, 1996, 1997  
+ * Copyright ViewTouch, Inc., 1995, 1996, 1997, 1998  
   
  *   This program is free software: you can redistribute it and/or modify 
  *   it under the terms of the GNU General Public License as published by 
@@ -16,9 +14,10 @@
  *   You should have received a copy of the GNU General Public License 
  *   along with this program.  If not, see <http://www.gnu.org/licenses/>. 
  *
- * basic.hh - revision 13 (10/20/98)
- * Basic Data Types & Definitions 
+ * basic.hh - Basic types & definitions
  */
+
+#pragma once
 
 #include <cstdio>
 #include <cstdlib>

--- a/changelog.md
+++ b/changelog.md
@@ -71,6 +71,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
   - Applied `const_cast<char*>()` fixes for X11/Motif compatibility in widget creation and dialog titles
 - **Build System**: Ensured complete compilation of all executables (vt_main, vt_term, vt_print, vt_cdu) and test suite
 - **Code Documentation**: Added comprehensive inline comments explaining all font system changes, cast fixes, and compatibility requirements for future maintenance
+- **CRITICAL DIRECTORY ACCESS ISSUE**: Fixed directory permission bug introduced during C++17 refactor that made `/usr/viewtouch/dat` inaccessible
+  - **Root Cause**: C++17 refactor added `umask(0111)` in `main/manager.cc` which removed execute permissions from all created directories
+  - **Impact**: Directories created with `mkdir(dirname, 0755)` resulted in 644 permissions instead of 755, breaking file manager access with "Access was denied" errors
+  - **Fix**: Changed `umask(0111)` to `umask(0022)` to preserve execute permissions needed for directory access while maintaining security
+  - **Directory Permissions**: Updated `scripts/vtcommands.pl` to use 0775 permissions for bin/dat directories to ensure consistency
+  - **Result**: Directories now receive proper 755 permissions (rwxr-xr-x) allowing normal file manager access
 - **CRITICAL TEST FAILURE**: Fixed `test_data_file` failure caused by incorrect format specifier in float serialization
   - **Float Format Bug in InputDataFile::Read()**: Fixed `sscanf(str, "%lf", &v)` bug in `data_file.cc` - wrong format specifier for `Flt` type
   - Root cause: `Flt` is typedef'd as `float` but Read method used `%lf` (double format) instead of `%f` (float format)

--- a/data_file.hh
+++ b/data_file.hh
@@ -1,4 +1,4 @@
-#pragma once  // REFACTOR: Replaced #ifndef VT_DATA_FILE_HH guard with modern pragma once
+#pragma once
 
 /*
  * Copyright ViewTouch, Inc., 1995, 1996, 1997, 1998  

--- a/debug.hh
+++ b/debug.hh
@@ -1,7 +1,5 @@
-#pragma once  // REFACTOR: Replaced #ifndef VT_DEBUG_HH guard with modern pragma once
-
 /*
- * Copyright ViewTouch, Inc., 1995, 1996, 1997  
+ * Copyright ViewTouch, Inc., 1995, 1996, 1997, 1998  
   
  *   This program is free software: you can redistribute it and/or modify 
  *   it under the terms of the GNU General Public License as published by 
@@ -16,8 +14,10 @@
  *   You should have received a copy of the GNU General Public License 
  *   along with this program.  If not, see <http://www.gnu.org/licenses/>. 
  *
- * debug.hh - revision 8 (9/3/98)
+ * debug.hh - Debug module
  */
+
+#pragma once
 
 #include "basic.hh"
 #include <X11/Xlib.h>

--- a/fntrace.hh
+++ b/fntrace.hh
@@ -1,5 +1,3 @@
-#pragma once  // REFACTOR: Replaced #ifndef VT_FNTRACE_HH guard with modern pragma once
-
 /*
  * Copyright ViewTouch, Inc., 1995, 1996, 1997, 1998  
   
@@ -16,9 +14,10 @@
  *   You should have received a copy of the GNU General Public License 
  *   along with this program.  If not, see <http://www.gnu.org/licenses/>. 
  *
- * fntrace.hh - revision 124 (10/6/98)
- * Implementation of fntrace module
+ * fntrace.hh - Function tracing module
  */
+
+#pragma once
 
 #include "basic.hh"
 #include <string>

--- a/generic_char.cc
+++ b/generic_char.cc
@@ -1,6 +1,9 @@
-
 #include "generic_char.hh"
 #include "basic.hh"
+#include "term/term_view.hh"  // For FONT_DEFAULT definition
+
+// Add Xft support for scalable font rendering
+#include <X11/Xft/Xft.h>
 
 #ifdef DMALLOC
 #include <dmalloc.h>
@@ -9,16 +12,62 @@
 /**** Global Variables ****/
 int is_wide_char = 0;   // zero for false, all else for true
 
+// Forward declaration for GetFontInfo - get the current font
+extern XftFont *GetFontInfo(int font_id);
+extern Display *Dis;  // External display reference
 
 void GenericDrawString(Display *display, Drawable d, GC gc, int x, int y, const genericChar* str, int length)
 {
     if (is_wide_char == 0)
     {
-        XDrawString(display, d, gc, x, y, str, length);
+        // Use Xft for scalable font rendering instead of deprecated XDrawString
+        if (display && d && str && length > 0)
+        {
+            // Create XftDraw for rendering
+            XftDraw *xftdraw = XftDrawCreate(display, d, 
+                                           DefaultVisual(display, DefaultScreen(display)), 
+                                           DefaultColormap(display, DefaultScreen(display)));
+            
+            if (xftdraw)
+            {
+                // Get current font (using default font)
+                XftFont *font = GetFontInfo(FONT_DEFAULT);
+                
+                if (font)
+                {
+                    // Create XftColor from current GC foreground
+                    XGCValues gcv;
+                    XGetGCValues(display, gc, GCForeground, &gcv);
+                    
+                    // Convert pixel to XColor then to XftColor
+                    XColor xcolor;
+                    xcolor.pixel = gcv.foreground;
+                    XQueryColor(display, DefaultColormap(display, DefaultScreen(display)), &xcolor);
+                    
+                    XRenderColor renderColor = {xcolor.red, xcolor.green, xcolor.blue, 0xffff};
+                    XftColor xftColor;
+                    XftColorAllocValue(display, DefaultVisual(display, DefaultScreen(display)), 
+                                     DefaultColormap(display, DefaultScreen(display)), 
+                                     &renderColor, &xftColor);
+                    
+                    // Draw the text using Xft
+                    XftDrawStringUtf8(xftdraw, &xftColor, font, x, y,
+                                    reinterpret_cast<const unsigned char*>(str), length);
+                    
+                    // Clean up
+                    XftColorFree(display, DefaultVisual(display, DefaultScreen(display)), 
+                               DefaultColormap(display, DefaultScreen(display)), &xftColor);
+                }
+                
+                XftDrawDestroy(xftdraw);
+            }
+        }
     }
     else
     {
-        // not specified yet 
+        // not specified yet - would handle wide character rendering
+        // For now, fall back to Xft rendering as well
+        GenericDrawString(display, d, gc, x, y, str, length);
     }
 }
 

--- a/image_data.hh
+++ b/image_data.hh
@@ -1,4 +1,4 @@
-#pragma once  // REFACTOR: Replaced #ifndef VT_IMAGE_DATA_HH guard with modern pragma once
+#pragma once
 
 /*
  * Copyright ViewTouch, Inc., 1995, 1996, 1997, 1998  

--- a/list_utility.hh
+++ b/list_utility.hh
@@ -16,7 +16,7 @@
  *			This needs to be fixed.
  */
 
-#pragma once  // REFACTOR: Replaced #ifndef VT_LIST_UTILITY_HH guard with modern pragma once
+#pragma once
 
 #include "basic.hh"
 #include "fntrace.hh"
@@ -30,7 +30,7 @@ class SList
 
 public:
     // Constructors
-    SList()           { list_head = nullptr; list_tail = nullptr; }  // REFACTOR: Changed NULL to nullptr for modern C++
+    SList()           { list_head = nullptr; list_tail = nullptr; }
     SList(type *item) { list_head = item; list_tail = item; }
 
     // Destructor
@@ -42,18 +42,18 @@ public:
 
     int IsEmpty()
     {
-        return (list_head == nullptr);  // REFACTOR: Changed NULL to nullptr for modern C++
+        return (list_head == nullptr);
     }
 
     int AddToHead(type *item)
     {
         FnTrace("SList::AddToHead()");
-        if (item == nullptr)            // REFACTOR: Changed NULL to nullptr for modern C++
+        if (item == nullptr)
             return 1;
 
         item->next = list_head;
 
-        if (list_tail == nullptr)       // REFACTOR: Changed NULL to nullptr for modern C++
+        if (list_tail == nullptr)
             list_tail = item;
 
         list_head = item;
@@ -63,10 +63,10 @@ public:
     int AddToTail(type *item)
     {
         FnTrace("SList::AddToTail()");
-        if (item == nullptr)        // REFACTOR: Changed NULL to nullptr for modern C++
+        if (item == nullptr)
             return 1;
 
-        item->next = nullptr;       // REFACTOR: Changed NULL to nullptr for modern C++
+        item->next = nullptr;
 
         if (list_tail)
             list_tail->next = item;
@@ -79,7 +79,7 @@ public:
     int AddAfterNode(type *node, type *item)
     {
         FnTrace("SList::AddAfterNode()");
-        if (node == nullptr)        // REFACTOR: Changed NULL to nullptr for modern C++
+        if (node == nullptr)
             return AddToHead(item);
         if (node == list_tail)
             return AddToTail(item);
@@ -98,15 +98,15 @@ public:
             list_head = list_head->next;
             delete tmp;
         }
-        list_tail = nullptr;        // REFACTOR: Changed NULL to nullptr for modern C++
+        list_tail = nullptr;
     }
 
     int Remove(type *node)
     {
         FnTrace("SList::Remove()");
-        if (node == nullptr)        // REFACTOR: Changed NULL to nullptr for modern C++
+        if (node == nullptr)
             return 1;
-        for (type *n = list_head, *p = nullptr; n != nullptr; p = n, n = n->next)  // REFACTOR: Changed NULL to nullptr for modern C++
+        for (type *n = list_head, *p = nullptr; n != nullptr; p = n, n = n->next)
             if (node == n)
             {
                 if (p)
@@ -115,7 +115,7 @@ public:
                     list_head = node->next;
                 if (list_tail == node)
                     list_tail = p;
-                node->next = nullptr;   // REFACTOR: Changed NULL to nullptr for modern C++
+                node->next = nullptr;
                 return 0;
             }
         return 1;
@@ -125,7 +125,7 @@ public:
     {
         FnTrace("SList::Count()");
         int count = 0;
-        for (type *n = list_head; n != nullptr; n = n->next)  // REFACTOR: Changed NULL to nullptr for modern C++
+        for (type *n = list_head; n != nullptr; n = n->next)
             ++count;
         return count;
     }
@@ -134,10 +134,10 @@ public:
     {
         FnTrace("SList::Index()");
         if (i < 0)
-            return nullptr;         // REFACTOR: Changed NULL to nullptr for modern C++
+            return nullptr;
 
         type *n = list_head;
-        while (n != nullptr && i > 0)  // REFACTOR: Changed NULL to nullptr for modern C++
+        while (n != nullptr && i > 0)
             --i, n = n->next;
         return n;
     }
@@ -156,16 +156,16 @@ class DList
         type *p, *q, *e, *tail;
         int insize, nmerges, psize, qsize, i;
         
-        if (list == nullptr)        // REFACTOR: Changed NULL to nullptr for modern C++
-            return nullptr;          // REFACTOR: Changed NULL to nullptr for modern C++
+        if (list == nullptr)
+            return nullptr;
 
         insize = 1;
         
         while (1)
         {
             p = list;
-            list = nullptr;          // REFACTOR: Changed NULL to nullptr for modern C++
-            tail = nullptr;          // REFACTOR: Changed NULL to nullptr for modern C++
+            list = nullptr;
+            tail = nullptr;
             
             nmerges = 0;  /* count number of merges we do in this pass */
             
@@ -225,7 +225,7 @@ class DList
                 /* now p has stepped `insize' places along, and q has too */
                 p = q;
             }
-            tail->next = nullptr;    // REFACTOR: Changed NULL to nullptr for modern C++
+            tail->next = nullptr;
             
             /* If we have done only one merge, we're finished. */
             if (nmerges <= 1)   /* allow for nmerges==0, the empty list case */
@@ -238,7 +238,7 @@ class DList
     
 public:
     // Constructors
-    DList()           { list_head = nullptr; list_tail = nullptr; }  // REFACTOR: Changed NULL to nullptr for modern C++
+    DList()           { list_head = nullptr; list_tail = nullptr; }
     DList(type *item) { list_head = item; list_tail = item; }
 
     // Destructor
@@ -254,16 +254,16 @@ public:
 
     int IsEmpty()
     {
-        return (list_head == nullptr);  // REFACTOR: Changed NULL to nullptr for modern C++
+        return (list_head == nullptr);
     }
 
     int AddToHead(type *item)
     {
         FnTrace("DList::AddToHead()");
-        if (item == nullptr)            // REFACTOR: Changed NULL to nullptr for modern C++
+        if (item == nullptr)
             return 1;
 
-        item->fore = nullptr;           // REFACTOR: Changed NULL to nullptr for modern C++
+        item->fore = nullptr;
         item->next = list_head;
         if (list_head)
             list_head->fore = item;
@@ -276,11 +276,11 @@ public:
     int AddToTail(type *item)
     {
         FnTrace("DList::AddToTail()");
-        if (item == nullptr)        // REFACTOR: Changed NULL to nullptr for modern C++
+        if (item == nullptr)
             return 1;
 
         item->fore = list_tail;
-        item->next = nullptr;       // REFACTOR: Changed NULL to nullptr for modern C++
+        item->next = nullptr;
         if (list_tail)
             list_tail->next = item;
         else
@@ -292,7 +292,7 @@ public:
     int AddAfterNode(type *node, type *item)
     {
         FnTrace("DList::AddAfterNode()");
-        if (node == nullptr)        // REFACTOR: Changed NULL to nullptr for modern C++
+        if (node == nullptr)
             return AddToHead(item);
         if (node == list_tail)
             return AddToTail(item);
@@ -307,7 +307,7 @@ public:
     int AddBeforeNode(type *node, type *item)
     {
         FnTrace("DList::AddBeforeNode()");
-        if (node == nullptr)        // REFACTOR: Changed NULL to nullptr for modern C++
+        if (node == nullptr)
             return AddToTail(item);
         if (node == list_head)
             return AddToHead(item);
@@ -322,13 +322,13 @@ public:
     int Exists(type *item, int (*cmp)(type *, type*))
     {
         FnTrace("DList::Exists()");
-        if (item == nullptr)        // REFACTOR: Changed NULL to nullptr for modern C++
+        if (item == nullptr)
             return 1;
 
         type *curr = list_head;
         int found = 0;
 
-        while (curr != nullptr && found == 0)  // REFACTOR: Changed NULL to nullptr for modern C++
+        while (curr != nullptr && found == 0)
         {
             if (cmp(item, curr) == 0)
                 found = 1;
@@ -342,7 +342,7 @@ public:
     int Remove(type *item)
     {
         FnTrace("DList::Remove()");
-        if (item == nullptr)        // REFACTOR: Changed NULL to nullptr for modern C++
+        if (item == nullptr)
             return 1;
 
         if (list_head == item)
@@ -353,17 +353,17 @@ public:
             item->next->fore = item->fore;
         if (item->fore)
             item->fore->next = item->next;
-        item->fore = nullptr;       // REFACTOR: Changed NULL to nullptr for modern C++
-        item->next = nullptr;       // REFACTOR: Changed NULL to nullptr for modern C++
+        item->fore = nullptr;
+        item->next = nullptr;
         return 0;
     }
 
     int RemoveSafe(type *node)
     {
         FnTrace("DList::RemoveSafe()");
-        if (node == nullptr)        // REFACTOR: Changed NULL to nullptr for modern C++
+        if (node == nullptr)
             return 1;
-        for (type *n = list_head; n != nullptr; n = n->next)  // REFACTOR: Changed NULL to nullptr for modern C++
+        for (type *n = list_head; n != nullptr; n = n->next)
             if (n == node)
                 return Remove(node);
         return 1;
@@ -379,14 +379,14 @@ public:
             list_head = list_head->next;
             delete tmp;
         }
-        list_tail = nullptr;        // REFACTOR: Changed NULL to nullptr for modern C++
+        list_tail = nullptr;
     }
 
     int Count() const
     {
         FnTrace("DList::Count()");
         int count = 0;
-        for (type *n = list_head; n != nullptr; n = n->next)  // REFACTOR: Changed NULL to nullptr for modern C++
+        for (type *n = list_head; n != nullptr; n = n->next)
             ++count;
         return count;
     }
@@ -395,10 +395,10 @@ public:
     {
         FnTrace("DList::Index()");
         if (i < 0)
-            return nullptr;         // REFACTOR: Changed NULL to nullptr for modern C++
+            return nullptr;
 
         type *n = list_head;
-        while (n != nullptr && i > 0)  // REFACTOR: Changed NULL to nullptr for modern C++
+        while (n != nullptr && i > 0)
         {
             --i;
             n = n->next;
@@ -411,9 +411,9 @@ public:
         FnTrace("DList::Sort()");
         list_head = InternalSort(list_head, cmp);
         list_tail = list_head;
-        if (list_tail != nullptr)          // REFACTOR: Changed NULL to nullptr for modern C++
+        if (list_tail != nullptr)
         {
-            while (list_tail->next != nullptr)  // REFACTOR: Changed NULL to nullptr for modern C++
+            while (list_tail->next != nullptr)
                 list_tail = list_tail->next;
         }
         return 0;

--- a/logger.hh
+++ b/logger.hh
@@ -1,4 +1,4 @@
-#pragma once  // REFACTOR: Replaced include guards with modern pragma once
+#pragma once
 
 /*
  * simple logging library - header

--- a/main/account.hh
+++ b/main/account.hh
@@ -18,7 +18,7 @@
  * Account handling class objects
  */
 
-#pragma once  // REFACTOR: Replaced #ifndef _ACCOUNT_HH guard with modern pragma once
+#pragma once
 
 #include "terminal.hh"
 #include "utility.hh"

--- a/main/archive.cc
+++ b/main/archive.cc
@@ -460,7 +460,7 @@ int Archive::LoadPacked(Settings *settings, const char* file)
         df.Read(advertise_fund);
 
     // Initialize Data
-    for (drawer = DrawerList(); drawer != nullptr; drawer = drawer->next) // REFACTOR: NULL -> nullptr for modern C++
+    for (drawer = DrawerList(); drawer != nullptr; drawer = drawer->next)
     {
         drawer->Total(CheckList());
     }
@@ -468,10 +468,10 @@ int Archive::LoadPacked(Settings *settings, const char* file)
     {
         Check *check = CheckList();
         SubCheck *subcheck;
-        while (check != nullptr) // REFACTOR: NULL -> nullptr for modern C++
+        while (check != nullptr)
         {
             subcheck = check->SubList();
-            while (subcheck != nullptr) // REFACTOR: NULL -> nullptr for modern C++
+            while (subcheck != nullptr)
             {
                 subcheck->archive = this;
                 subcheck->FigureTotals(settings);
@@ -687,7 +687,7 @@ int Archive::SavePacked()
     df.Write(media_version);
     df.Write(DiscountCount());
     DiscountInfo *discount = DiscountList();
-    while (discount != nullptr) // REFACTOR: NULL -> nullptr for modern C++
+    while (discount != nullptr)
     {
         discount->Write(df, media_version);
         discount = discount->next;
@@ -695,7 +695,7 @@ int Archive::SavePacked()
 
     df.Write(CouponCount());
     CouponInfo *coupon = CouponList();
-    while (coupon != nullptr) // REFACTOR: NULL -> nullptr for modern C++
+    while (coupon != nullptr)
     {
         coupon->Write(df, media_version);
         coupon = coupon->next;
@@ -703,7 +703,7 @@ int Archive::SavePacked()
 
     df.Write(CreditCardCount());
     CreditCardInfo *creditcard = CreditCardList();
-    while (creditcard != nullptr) // REFACTOR: NULL -> nullptr for modern C++
+    while (creditcard != nullptr)
     {
         creditcard->Write(df, media_version);
         creditcard = creditcard->next;
@@ -711,7 +711,7 @@ int Archive::SavePacked()
 
     df.Write(CompCount());
     CompInfo *comp = CompList();
-    while (comp != nullptr) // REFACTOR: NULL -> nullptr for modern C++
+    while (comp != nullptr)
     {
         comp->Write(df, media_version);
         comp = comp->next;
@@ -719,7 +719,7 @@ int Archive::SavePacked()
 
     df.Write(MealCount());
     MealInfo *meal = MealList();
-    while (meal != nullptr) // REFACTOR: NULL -> nullptr for modern C++
+    while (meal != nullptr)
     {
         meal->Write(df, media_version);
         meal = meal->next;
@@ -742,23 +742,23 @@ int Archive::SavePacked()
     df.Write(discount_alcohol);
     df.Write(tax_VAT);
 
-    if (cc_exception_db == nullptr) // REFACTOR: NULL -> nullptr for modern C++
+    if (cc_exception_db == nullptr)
         cc_exception_db = new CreditDB(CC_DBTYPE_EXCEPT);
     cc_exception_db->Write(df);
-    if (cc_refund_db == nullptr) // REFACTOR: NULL -> nullptr for modern C++
+    if (cc_refund_db == nullptr)
         cc_refund_db = new CreditDB(CC_DBTYPE_REFUND);
     cc_refund_db->Write(df);
-    if (cc_void_db == nullptr) // REFACTOR: NULL -> nullptr for modern C++
+    if (cc_void_db == nullptr)
         cc_void_db = new CreditDB(CC_DBTYPE_VOID);
     cc_void_db->Write(df);
 
-    if (cc_init_results == nullptr) // REFACTOR: NULL -> nullptr for modern C++
+    if (cc_init_results == nullptr)
         cc_init_results = new CCInit();
     cc_init_results->Write(df);
-    if (cc_saf_details_results == nullptr) // REFACTOR: NULL -> nullptr for modern C++
+    if (cc_saf_details_results == nullptr)
         cc_saf_details_results = new CCSAFDetails();
     cc_saf_details_results->Write(df);
-    if (cc_settle_results == nullptr) // REFACTOR: NULL -> nullptr for modern C++
+    if (cc_settle_results == nullptr)
         cc_settle_results = new CCSettle();
     cc_settle_results->Write(df);
 
@@ -792,22 +792,22 @@ int Archive::Unload()
     expense_db.Purge();
 
     delete cc_exception_db;
-    cc_exception_db = nullptr; // REFACTOR: NULL -> nullptr for modern C++
+    cc_exception_db = nullptr;
 
     delete cc_refund_db;
-    cc_refund_db = nullptr; // REFACTOR: NULL -> nullptr for modern C++
+    cc_refund_db = nullptr;
 
     delete cc_void_db;
-    cc_void_db = nullptr; // REFACTOR: NULL -> nullptr for modern C++
+    cc_void_db = nullptr;
 
     delete cc_init_results;
-    cc_init_results = nullptr; // REFACTOR: NULL -> nullptr for modern C++
+    cc_init_results = nullptr;
 
     delete cc_saf_details_results;
-    cc_saf_details_results = nullptr; // REFACTOR: NULL -> nullptr for modern C++
+    cc_saf_details_results = nullptr;
 
     delete cc_settle_results;
-    cc_settle_results = nullptr; // REFACTOR: NULL -> nullptr for modern C++
+    cc_settle_results = nullptr;
 
     loaded = 0;
     return 0;
@@ -816,7 +816,7 @@ int Archive::Unload()
 int Archive::Add(Check *c)
 {
     FnTrace("Archive::Add(Check)");
-    if (loaded == 0 || c == nullptr || c->Status() == CHECK_OPEN) // REFACTOR: NULL -> nullptr for modern C++
+    if (loaded == 0 || c == nullptr || c->Status() == CHECK_OPEN)
         return 1; // can't archive open check
 
     c->archive = this;
@@ -831,10 +831,10 @@ int Archive::Add(Check *c)
 int Archive::Remove(Check *c)
 {
     FnTrace("Archive::Remove(Check)");
-    if (c == nullptr || c->archive != this) // REFACTOR: NULL -> nullptr for modern C++
+    if (c == nullptr || c->archive != this)
         return 1;
 
-    c->archive = nullptr; // REFACTOR: NULL -> nullptr for modern C++
+    c->archive = nullptr;
     check_list.Remove(c);
 
     changed = 1;
@@ -844,7 +844,7 @@ int Archive::Remove(Check *c)
 int Archive::Add(Drawer *drawer)
 {
     FnTrace("Archive::Add(Drawer)");
-    if (drawer == nullptr || loaded == 0) // REFACTOR: NULL -> nullptr for modern C++
+    if (drawer == nullptr || loaded == 0)
         return 1;
 
     drawer->archive = this;
@@ -860,10 +860,10 @@ int Archive::Add(Drawer *drawer)
 int Archive::Remove(Drawer *drawer)
 {
     FnTrace("Archive::Remove(Drawer)");
-    if (drawer == nullptr || drawer->archive != this) // REFACTOR: NULL -> nullptr for modern C++
+    if (drawer == nullptr || drawer->archive != this)
         return 1;
 
-    drawer->archive = nullptr; // REFACTOR: NULL -> nullptr for modern C++
+    drawer->archive = nullptr;
     drawer_list.Remove(drawer);
 
     changed = 1;
@@ -873,7 +873,7 @@ int Archive::Remove(Drawer *drawer)
 int Archive::Add(WorkEntry *we)
 {
     FnTrace("Archive::Add(WorkEntry)");
-    if (we == nullptr || loaded == 0) // REFACTOR: NULL -> nullptr for modern C++
+    if (we == nullptr || loaded == 0)
         return 1;
 
     work_db.Add(we);
@@ -890,7 +890,7 @@ int Archive::Remove(WorkEntry *we)
 int Archive::Add(DiscountInfo *discount)
 {
     FnTrace("Archive::Add(Discount)");
-    if (discount == nullptr) // REFACTOR: NULL -> nullptr for modern C++
+    if (discount == nullptr)
         return 1;
     return discount_list.AddToTail(discount);
 }
@@ -898,7 +898,7 @@ int Archive::Add(DiscountInfo *discount)
 int Archive::Add(CouponInfo *coupon)
 {
     FnTrace("Archive::Add(Coupon)");
-    if (coupon == nullptr) // REFACTOR: NULL -> nullptr for modern C++
+    if (coupon == nullptr)
         return 1;
     return coupon_list.AddToTail(coupon);
 }
@@ -906,7 +906,7 @@ int Archive::Add(CouponInfo *coupon)
 int Archive::Add(CreditCardInfo *creditcard)
 {
     FnTrace("Archive::Add(CreditCard)");
-    if (creditcard == nullptr) // REFACTOR: NULL -> nullptr for modern C++
+    if (creditcard == nullptr)
         return 1;
     return creditcard_list.AddToTail(creditcard);
 }
@@ -914,7 +914,7 @@ int Archive::Add(CreditCardInfo *creditcard)
 int Archive::Add(CompInfo *comp)
 {
     FnTrace("Archive::Add(Comp)");
-    if (comp == nullptr) // REFACTOR: NULL -> nullptr for modern C++
+    if (comp == nullptr)
         return 1;
     return comp_list.AddToTail(comp);
 }
@@ -922,7 +922,7 @@ int Archive::Add(CompInfo *comp)
 int Archive::Add(MealInfo *meal)
 {
     FnTrace("Archive::Add(Meal)");
-    if (meal == nullptr) // REFACTOR: NULL -> nullptr for modern C++
+    if (meal == nullptr)
         return 1;
     return meal_list.AddToTail(meal);
 }
@@ -932,7 +932,7 @@ int Archive::DiscountCount()
     FnTrace("Archive::DiscountCount()");
     int count = 0;
     DiscountInfo *discount = DiscountList();
-    while (discount != nullptr) // REFACTOR: NULL -> nullptr for modern C++
+    while (discount != nullptr)
     {
         count += 1;
         discount = discount->next;
@@ -945,7 +945,7 @@ int Archive::CouponCount()
     FnTrace("Archive::CouponCount()");
     int count = 0;
     CouponInfo *coupon = CouponList();
-    while (coupon != nullptr) // REFACTOR: NULL -> nullptr for modern C++
+    while (coupon != nullptr)
     {
         count += 1;
         coupon = coupon->next;
@@ -958,7 +958,7 @@ int Archive::CreditCardCount()
     FnTrace("Archive::CreditCardCount()");
     int count = 0;
     CreditCardInfo *creditcard = CreditCardList();
-    while (creditcard != nullptr) // REFACTOR: NULL -> nullptr for modern C++
+    while (creditcard != nullptr)
     {
         count += 1;
         creditcard = creditcard->next;
@@ -971,7 +971,7 @@ int Archive::CompCount()
     FnTrace("Archive::CompCount()");
     int count = 0;
     CompInfo *comp = CompList();
-    while (comp != nullptr) // REFACTOR: NULL -> nullptr for modern C++
+    while (comp != nullptr)
     {
         count += 1;
         comp = comp->next;
@@ -984,7 +984,7 @@ int Archive::MealCount()
     FnTrace("Archive::MealCount()");
     int count = 0;
     MealInfo *meal = MealList();
-    while (meal != nullptr) // REFACTOR: NULL -> nullptr for modern C++
+    while (meal != nullptr)
     {
         count += 1;
         meal = meal->next;
@@ -995,54 +995,54 @@ int Archive::MealCount()
 DiscountInfo *Archive::FindDiscountByID(int discount_id)
 {
     FnTrace("Archive::FindDiscountByID()");
-    for (DiscountInfo *ds = discount_list.Head(); ds != nullptr; ds = ds->next) // REFACTOR: NULL -> nullptr for modern C++
+    for (DiscountInfo *ds = discount_list.Head(); ds != nullptr; ds = ds->next)
     {
         if (ds->id == discount_id)
             return ds;
     }
-    return nullptr; // REFACTOR: NULL -> nullptr for modern C++
+    return nullptr;
 }
 
 CouponInfo *Archive::FindCouponByID(int coupon_id)
 {
     FnTrace("Archive::FindCouponByID()");
-    for (CouponInfo *cp = coupon_list.Head(); cp != nullptr; cp = cp->next) // REFACTOR: NULL -> nullptr for modern C++
+    for (CouponInfo *cp = coupon_list.Head(); cp != nullptr; cp = cp->next)
     {
         if (cp->id == coupon_id)
             return cp;
     }
-    return nullptr; // REFACTOR: NULL -> nullptr for modern C++
+    return nullptr;
 }
 
 CompInfo *Archive::FindCompByID(int comp_id)
 {
     FnTrace("Archive::FindCompByID()");
-    for (CompInfo *cm = comp_list.Head(); cm != nullptr; cm = cm->next) // REFACTOR: NULL -> nullptr for modern C++
+    for (CompInfo *cm = comp_list.Head(); cm != nullptr; cm = cm->next)
     {
         if (cm->id == comp_id)
             return cm;
     }
-    return nullptr; // REFACTOR: NULL -> nullptr for modern C++
+    return nullptr;
 }
 
 CreditCardInfo *Archive::FindCreditCardByID(int creditcard_id)
 {
     FnTrace("Archive::FindCreditCardByID()");
-    for (CreditCardInfo *cc = creditcard_list.Head(); cc != nullptr; cc = cc->next) // REFACTOR: NULL -> nullptr for modern C++
+    for (CreditCardInfo *cc = creditcard_list.Head(); cc != nullptr; cc = cc->next)
     {
         if (cc->id == creditcard_id)
             return cc;
     }
-    return nullptr; // REFACTOR: NULL -> nullptr for modern C++
+    return nullptr;
 }
 
 MealInfo *Archive::FindMealByID(int meal_id)
 {
     FnTrace("Archive::FindMealByID()");
-    for (MealInfo *mi = meal_list.Head(); mi != nullptr; mi = mi->next) // REFACTOR: NULL -> nullptr for modern C++
+    for (MealInfo *mi = meal_list.Head(); mi != nullptr; mi = mi->next)
     {
         if (mi->id == meal_id)
             return mi;
     }
-    return nullptr; // REFACTOR: NULL -> nullptr for modern C++
+    return nullptr;
 }

--- a/main/cdu.hh
+++ b/main/cdu.hh
@@ -19,7 +19,7 @@
  *   display styles (slide in from left, fade in, etc.), and that sort of thing.
  */
 
-#pragma once  // REFACTOR: Replaced #ifndef CDU_HH guard with modern pragma once
+#pragma once
 
 #include "list_utility.hh"
 #include "data_file.hh"
@@ -92,7 +92,7 @@ public:
     int             Read(InputDataFile &infile, int version);
     int             Write(OutputDataFile &outfile, int version);
     int             Load(const char* path);
-    int             Save(const char* path = nullptr);  // REFACTOR: Changed NULL to nullptr for modern C++
+    int             Save(const char* path = nullptr);
     int             RemoveBlank();
     int             Remove(CDUString *cdustr);
     CDUString      *GetString(int idx = -1);

--- a/main/chart.hh
+++ b/main/chart.hh
@@ -18,7 +18,7 @@
  * Report container
  */
 
-#pragma once  // REFACTOR: Replaced #ifndef _CHART_HH guard with modern pragma once
+#pragma once
 
 #include "list_utility.hh"
 #include "utility.hh"

--- a/main/check.hh
+++ b/main/check.hh
@@ -18,7 +18,7 @@
  * Definition of check management classes
  */
 
-#pragma once  // REFACTOR: Replaced #ifndef _CHECK_HH guard with modern pragma once
+#pragma once
 
 #include "utility.hh"
 #include "list_utility.hh"
@@ -180,13 +180,13 @@ public:
     int        Add(Order *o);  // Add a modifier order
     int        Remove(Order *o);  // Removes a modifier order
     int        FigureCost();  // Totals up order
-    genericChar* Description(Terminal *t, genericChar* buffer = nullptr);  // REFACTOR: Changed NULL to nullptr for modern C++
-    genericChar* PrintDescription( genericChar* str=nullptr, short int pshort = 0 );  // REFACTOR: Changed NULL to nullptr for modern C++
+    genericChar* Description(Terminal *t, genericChar* buffer = nullptr);
+    genericChar* PrintDescription( genericChar* str=nullptr, short int pshort = 0 );
     int        IsEntree();  // boolean - is this item an "Entree"?
     int        FindPrinterID(Settings *settings);  // PrinterID (based on family) for order
     SalesItem *Item(ItemDB *db);  // Returns menu item this order points to
     int        PrintStatus(Terminal *t, int printer_id, int reprint = 0, int flag_sent = ORDER_SENT);  // Returns 0-don't print, 1-print, 2-notify only
-    genericChar* Seat(Settings *settings, genericChar* buffer = nullptr);  // REFACTOR: Changed NULL to nullptr for modern C++
+    genericChar* Seat(Settings *settings, genericChar* buffer = nullptr);
     int        IsModifier();  // Boolean - Is this order a modifier?
     int        CanDiscount(int discount_alcohol, Payment *p);  // Boolean - Does this discount apply?
     int        Finalize();  // Finalizes order
@@ -220,7 +220,7 @@ public:
     Payment *Copy();  // Returns exact copy of payment object
     int      Read(InputDataFile &df, int version);  // Reads payment from a file
     int      Write(OutputDataFile &df, int version);  // Write payment to a file
-    genericChar* Description(Settings *settings, genericChar* str = nullptr);  // REFACTOR: Changed NULL to nullptr for modern C++
+    genericChar* Description(Settings *settings, genericChar* str = nullptr);
     int      Priority();  // Sorting priority (higher goes 1st)
     int      Suppress();  // Boolean - Should payment be shown?
     int      IsDiscount();  // Boolean - Is payment a discount?
@@ -305,13 +305,13 @@ public:
     }
 
     SubCheck *Copy(Settings *settings);  // Creates a subcheck copy
-    int       Copy(SubCheck *sc, Settings *settings = nullptr, int restore = 0);  // REFACTOR: Changed NULL to nullptr for modern C++
+    int       Copy(SubCheck *sc, Settings *settings = nullptr, int restore = 0);
     int       Read(Settings *settings, InputDataFile &df, int version);  // Reads subcheck from file
     int       Write(OutputDataFile &df, int version);  // Writes subcheck to file
-    int       Add(Order *o, Settings *settings = nullptr);  // REFACTOR: Changed NULL to nullptr for modern C++
-    int       Add(Payment *p, Settings *settings = nullptr);  // REFACTOR: Changed NULL to nullptr for modern C++
-    int       Remove(Order *o, Settings *settings = nullptr);  // REFACTOR: Changed NULL to nullptr for modern C++
-    int       Remove(Payment *p, Settings *settings = nullptr);  // REFACTOR: Changed NULL to nullptr for modern C++
+    int       Add(Order *o, Settings *settings = nullptr);
+    int       Add(Payment *p, Settings *settings = nullptr);
+    int       Remove(Order *o, Settings *settings = nullptr);
+    int       Remove(Payment *p, Settings *settings = nullptr);
     int       Purge(int restore = 0);  // Removes all payments & orders
     Order    *RemoveOne(Order *o);  // Removes one order & returns it
     Order    *RemoveCount(Order *o, int count = 1);
@@ -321,13 +321,13 @@ public:
     int       FigureTotals(Settings *settings);  // Totals costs & payments
     int       TabRemain();
     int       SettleTab(Terminal *term, int payment_type, int payment_id, int payment_flags);
-    int       ConsolidateOrders(Settings *settings = nullptr, int relaxed = 0);  // REFACTOR: Changed NULL to nullptr for modern C++
-    int       ConsolidatePayments(Settings *settings = nullptr);  // REFACTOR: Changed NULL to nullptr for modern C++
+    int       ConsolidateOrders(Settings *settings = nullptr, int relaxed = 0);
+    int       ConsolidatePayments(Settings *settings = nullptr);
     int       FinalizeOrders();  // Makes all ordered items final
     int       Void();  // Voids check
     int       SeatsUsed();  // number of seats with orders
     int       PrintReceipt(Terminal *t, Check *c, Printer *p,
-                           Drawer *d = nullptr, int open_drawer = 0);  // REFACTOR: Changed NULL to nullptr for modern C++
+                           Drawer *d = nullptr, int open_drawer = 0);
     int       ReceiptReport(Terminal *t, Check *c, Drawer *d, Report *r);  // Makes report of receipt
     const genericChar* StatusString(Terminal *t);  // Returns string with subcheck status (Open, Closed, Voided, etc.)
     int       IsSeatOnCheck(int seat);  // Boolean - Are any of the orders for this seat?
@@ -397,7 +397,7 @@ public:
 
     // Constructors
     Check();
-    Check(Settings *settings, int customer_type, Employee *e = nullptr);  // REFACTOR: Changed NULL to nullptr for modern C++
+    Check(Settings *settings, int customer_type, Employee *e = nullptr);
     // Destructor
     ~Check();
 
@@ -435,19 +435,19 @@ public:
                          int flag_sent = ORDER_SENT);  // returns # of orders to be printed
     int       SendWorkOrder(Terminal *term, int printer_target, int reprint);
     int       PrintWorkOrder(Terminal *term, Report *report, int printer_id, int reprint,
-                             ReportZone *rzone = nullptr, Printer *printer = nullptr);  // REFACTOR: Changed NULL to nullptr for modern C++
+                             ReportZone *rzone = nullptr, Printer *printer = nullptr);
     int       PrintDeliveryOrder(Report *report, int pwidth = 80);
     int       PrintCustomerInfo(Printer *printer, int mode);
     int       PrintCustomerInfoReport(Report *report, int mode, int columns = 1, int pwidth = 40);
     int       ListOrdersForReport(Terminal *term, Report *report);
     int       MakeReport(Terminal *t, Report *r, int show_what = CHECK_DISPLAY_ALL,
-                         int video_target = PRINTER_DEFAULT, ReportZone *rzone = nullptr);  // REFACTOR: Changed NULL to nullptr for modern C++
+                         int video_target = PRINTER_DEFAULT, ReportZone *rzone = nullptr);
     int       HasOpenTab();
     int       IsEmpty();  // boolean - is check blank?
     int       IsTraining();  // boolean - is this a training check?
     int       EntreeCount(int seat);  // counts total entrees at seat
     SubCheck *FirstOpenSubCheck(int seat = -1);  // returns 1st open subcheck (by seat if needed) - sets current_sub
-    SubCheck *NextOpenSubCheck(SubCheck *sc = nullptr);  // REFACTOR: Changed NULL to nullptr for modern C++
+    SubCheck *NextOpenSubCheck(SubCheck *sc = nullptr);
     TimeInfo *TimeClosed();  // returns ptr to time closed
     int       WhoGetsSale(Settings *settings);  // returns user_id of server
     int       SecondsOpen();  // total number of seconds open
@@ -463,30 +463,30 @@ public:
     int       IsToGo();
     int       IsForHere();
     int       CustomerType(int set = -1);
-    const genericChar* Table(const genericChar* set = nullptr);  // REFACTOR: Changed NULL to nullptr for modern C++
+    const genericChar* Table(const genericChar* set = nullptr);
     int       Guests(int guests = -1);
     int              CallCenterID(int set = -1);
     int              CustomerID(int set = -1);
-    const genericChar* LastName(const genericChar* set = nullptr);  // REFACTOR: Changed NULL to nullptr for modern C++
-    const genericChar* FirstName(const genericChar* set = nullptr);  // REFACTOR: Changed NULL to nullptr for modern C++
-    genericChar* FullName(genericChar* dest = nullptr);  // REFACTOR: Changed NULL to nullptr for modern C++
-    const genericChar* Company(const genericChar* set = nullptr);  // REFACTOR: Changed NULL to nullptr for modern C++
-    const genericChar* Address(const genericChar* set = nullptr);  // REFACTOR: Changed NULL to nullptr for modern C++
-    const genericChar* Address2(const genericChar* set = nullptr);  // REFACTOR: Changed NULL to nullptr for modern C++
-    const genericChar* CrossStreet(const genericChar* set = nullptr);  // REFACTOR: Changed NULL to nullptr for modern C++
-    const genericChar* City(const genericChar* set = nullptr);  // REFACTOR: Changed NULL to nullptr for modern C++
-    const genericChar* State(const genericChar* set = nullptr);  // REFACTOR: Changed NULL to nullptr for modern C++
-    const genericChar* Postal(const genericChar* set = nullptr);  // REFACTOR: Changed NULL to nullptr for modern C++
-    const genericChar* Vehicle(const genericChar* set = nullptr);  // REFACTOR: Changed NULL to nullptr for modern C++
-    const genericChar* CCNumber(const genericChar* set = nullptr);  // REFACTOR: Changed NULL to nullptr for modern C++
-    const genericChar* CCExpire(const genericChar* set = nullptr);  // REFACTOR: Changed NULL to nullptr for modern C++
-    const genericChar* License(const genericChar* set = nullptr);  // REFACTOR: Changed NULL to nullptr for modern C++
-    const genericChar* Comment(const genericChar* set = nullptr);  // REFACTOR: Changed NULL to nullptr for modern C++
-    const genericChar* PhoneNumber(const genericChar* set = nullptr);  // REFACTOR: Changed NULL to nullptr for modern C++
-    const genericChar* Extension(const genericChar* set = nullptr);  // REFACTOR: Changed NULL to nullptr for modern C++
-    TimeInfo        *Date(TimeInfo *set = nullptr);  // REFACTOR: Changed NULL to nullptr for modern C++
-    TimeInfo        *CheckIn(TimeInfo *timevar = nullptr);  // REFACTOR: Changed NULL to nullptr for modern C++
-    TimeInfo        *CheckOut(TimeInfo *timevar = nullptr);  // REFACTOR: Changed NULL to nullptr for modern C++
+    const genericChar* LastName(const genericChar* set = nullptr);
+    const genericChar* FirstName(const genericChar* set = nullptr);
+    genericChar* FullName(genericChar* dest = nullptr);
+    const genericChar* Company(const genericChar* set = nullptr);
+    const genericChar* Address(const genericChar* set = nullptr);
+    const genericChar* Address2(const genericChar* set = nullptr);
+    const genericChar* CrossStreet(const genericChar* set = nullptr);
+    const genericChar* City(const genericChar* set = nullptr);
+    const genericChar* State(const genericChar* set = nullptr);
+    const genericChar* Postal(const genericChar* set = nullptr);
+    const genericChar* Vehicle(const genericChar* set = nullptr);
+    const genericChar* CCNumber(const genericChar* set = nullptr);
+    const genericChar* CCExpire(const genericChar* set = nullptr);
+    const genericChar* License(const genericChar* set = nullptr);
+    const genericChar* Comment(const genericChar* set = nullptr);
+    const genericChar* PhoneNumber(const genericChar* set = nullptr);
+    const genericChar* Extension(const genericChar* set = nullptr);
+    TimeInfo        *Date(TimeInfo *set = nullptr);
+    TimeInfo        *CheckIn(TimeInfo *timevar = nullptr);
+    TimeInfo        *CheckOut(TimeInfo *timevar = nullptr);
 };
 
 /**** General Functions ****/

--- a/main/credit.cc
+++ b/main/credit.cc
@@ -18,8 +18,6 @@
  * Implementation of credit module
  */
 
-#pragma once  // REFACTOR: Replaced #ifndef _FILENAME_HH guard with modern pragma once
-
 #include "check.hh"
 #include "data_file.hh"
 #include "labels.hh"
@@ -103,8 +101,8 @@ Credit::Credit()
 {
     FnTrace("Credit::Credit()");
 
-    fore = nullptr; // REFACTOR: NULL -> nullptr for modern C++
-    next = nullptr; // REFACTOR: NULL -> nullptr for modern C++
+    fore = nullptr;
+    next = nullptr;
 
     Clear();
 }
@@ -113,12 +111,12 @@ Credit::Credit(const char* value)
 {
     FnTrace("Credit::Credit(const char* )");
 
-    fore = nullptr; // REFACTOR: NULL -> nullptr for modern C++
-    next = nullptr; // REFACTOR: NULL -> nullptr for modern C++
+    fore = nullptr;
+    next = nullptr;
 
     Clear();
 
-    if (value != nullptr) // REFACTOR: NULL -> nullptr for modern C++
+    if (value != nullptr)
     {
         swipe.Set(value);
         valid = ParseSwipe(value);
@@ -413,7 +411,7 @@ int Credit::Write(OutputDataFile &df, int version)
     error += df.Write(settle_time);
 
     error += df.Write(errors_list.Count());
-    while (ecredit != nullptr) // REFACTOR: NULL -> nullptr for modern C++
+    while (ecredit != nullptr)
     {
         ecredit->Write(df, version);
         ecredit = ecredit->next;
@@ -449,7 +447,7 @@ Credit *Credit::Copy()
     Credit *newcredit = new Credit();
     Credit *ecredit;
 
-    if (newcredit != nullptr) // REFACTOR: NULL -> nullptr for modern C++
+    if (newcredit != nullptr)
     {
         newcredit->card_id = card_id;
         newcredit->db_type   = db_type;
@@ -515,7 +513,7 @@ Credit *Credit::Copy()
         newcredit->read_manual = read_manual;
 
         ecredit = errors_list.Head();
-        while (ecredit != nullptr) // REFACTOR: NULL -> nullptr for modern C++
+        while (ecredit != nullptr)
         {
             newcredit->AddError(ecredit);
             ecredit = ecredit->next;
@@ -534,7 +532,7 @@ int Credit::Copy(Credit *credit)
     Credit *ecredit;
     int retval = 1;
 
-    if (credit != nullptr) // REFACTOR: NULL -> nullptr for modern C++
+    if (credit != nullptr)
     {
         card_id = credit->card_id;
         db_type   = credit->db_type;
@@ -1203,7 +1201,7 @@ int Credit::ParseSwipe(const char* value)
 int Credit::ParseApproval(const char* value)
 {
     FnTrace("Credit::ParseApproval()");
-    if (value == nullptr) // REFACTOR: NULL -> nullptr for modern C++
+    if (value == nullptr)
         return 1;
 
     char  str[256];
@@ -1282,9 +1280,9 @@ char* Credit::CreditTypeName(char* str, int shortname)
 {
     FnTrace("Credit::CreditTypeName()");
     static char buffer[32];
-    const char* hold = nullptr; // REFACTOR: NULL -> nullptr for modern C++
+    const char* hold = nullptr;
 
-    if (str == nullptr) // REFACTOR: NULL -> nullptr for modern C++
+    if (str == nullptr)
         str = buffer;
 
     strcpy(str, UnknownStr);
@@ -1311,7 +1309,7 @@ char* Credit::CreditTypeName(char* str, int shortname)
         }
     }
 
-    if (hold != nullptr) // REFACTOR: NULL -> nullptr for modern C++
+    if (hold != nullptr)
         strcpy(str, hold);
 
     return str;
@@ -1682,7 +1680,7 @@ char* Credit::LastFour(char* dest)
     int sidx = 0;
     int didx = 0;
     int len = 0;
-    if (dest == nullptr) // REFACTOR: NULL -> nullptr for modern C++ - eliminates ambiguous NULL macro, improves type safety
+    if (dest == nullptr)
         dest = str;
 
     if (number.size() > 0)
@@ -1834,7 +1832,7 @@ int Credit::MaskCardNumber()
 {
     FnTrace("Credit::MaskCardNumber()");
     int retval = 0;
-    const char* cardnum = nullptr; // REFACTOR: NULL -> nullptr for modern C++
+    const char* cardnum = nullptr;
 
     cardnum = PAN(0);
     number.Set(cardnum);
@@ -1900,7 +1898,7 @@ int Credit::SetBatch(long long batchnum, const char* btermid)
     FnTrace("Credit::SetBatch()");
     int retval = 1;
 
-    if (btermid != nullptr) // REFACTOR: NULL -> nullptr for modern C++
+    if (btermid != nullptr)
     {
         if (batch <= 0 && strcmp(batch_term_id.Value(), btermid) == 0)
         {
@@ -1968,7 +1966,7 @@ int Credit::GetApproval(Terminal *term)
     FnTrace("Credit::GetApproval()");
     int retval = 1;
 
-    if (term->credit != nullptr && term->credit != this) // REFACTOR: NULL -> nullptr for modern C++
+    if (term->credit != nullptr && term->credit != this)
     {
         if (debug_mode) printf("Have stale card in GetApproval...\n");
     }
@@ -1984,7 +1982,7 @@ int Credit::GetPreApproval(Terminal *term)
     FnTrace("Credit::GetPreApproval()");
     int retval = 1;
     
-    if (term->credit != nullptr && term->credit != this) // REFACTOR: NULL -> nullptr for modern C++
+    if (term->credit != nullptr && term->credit != this)
     {
         if (debug_mode) printf("Have stale card in GetPreApproval...\n");
     }
@@ -2000,7 +1998,7 @@ int Credit::GetFinalApproval(Terminal *term)
     FnTrace("Credit::GetFinalApproval()");
     int retval = 1;
 
-    if (term->credit != nullptr && term->credit != this) // REFACTOR: NULL -> nullptr for modern C++
+    if (term->credit != nullptr && term->credit != this)
     {
         if (debug_mode) printf("Have stale card in GetFinalApproval...\n");
     }
@@ -2016,7 +2014,7 @@ int Credit::GetVoid(Terminal *term)
     FnTrace("Credit::GetVoid()");
     int retval = 1;
 
-    if (term->credit != nullptr && term->credit != this) // REFACTOR: NULL -> nullptr for modern C++
+    if (term->credit != nullptr && term->credit != this)
     {
         if (debug_mode) printf("Have stale card in GetVoid...\n");
     }
@@ -2032,7 +2030,7 @@ int Credit::GetVoidCancel(Terminal *term)
     FnTrace("Credit::GetVoidCancel()");
     int retval = 1;
 
-    if (term->credit != nullptr && term->credit != this) // REFACTOR: NULL -> nullptr for modern C++
+    if (term->credit != nullptr && term->credit != this)
     {
         if (debug_mode) printf("Have stale card in GetVoidCancel...\n");
     }
@@ -2048,7 +2046,7 @@ int Credit::GetRefund(Terminal *term)
     FnTrace("Credit::GetRefund()");
     int retval = 1;
 
-    if (term->credit != nullptr && term->credit != this) // REFACTOR: NULL -> nullptr for modern C++
+    if (term->credit != nullptr && term->credit != this)
     {
         if (debug_mode) printf("Have stale card in GetRefund...\n");
     }
@@ -2064,7 +2062,7 @@ int Credit::GetRefundCancel(Terminal *term)
     FnTrace("Credit::GetRefundCancel()");
     int retval = 1;
 
-    if (term->credit != nullptr && term->credit != this) // REFACTOR: NULL -> nullptr for modern C++
+    if (term->credit != nullptr && term->credit != this)
     {
         if (debug_mode) printf("Have stale card in GetRefundCancel...\n");
     }
@@ -2099,9 +2097,9 @@ int Credit::ReceiptPrint(Terminal *term, int receipt_type, Printer *pprinter, in
     static int count = 0;  // for saving receipts for Moneris testing
     Check *parent = term->system_data->FindCheckByID(check_id);
 
-    if (printer == nullptr) // REFACTOR: NULL -> nullptr for modern C++
+    if (printer == nullptr)
         printer = term->FindPrinter(PRINTER_RECEIPT);
-    if (printer != nullptr) // REFACTOR: NULL -> nullptr for modern C++
+    if (printer != nullptr)
     {
         pwidth = printer->MaxWidth();
         snprintf(line, STRLENGTH, "%*s", pwidth, "________________");
@@ -2185,7 +2183,7 @@ int Credit::ReceiptPrint(Terminal *term, int receipt_type, Printer *pprinter, in
         // card and date information
         if (settings->cc_print_custinfo)
         {
-            if (parent != nullptr) // REFACTOR: NULL -> nullptr for modern C++
+            if (parent != nullptr)
             {
                 int did_print = 0;
                 strcpy(buffer2, parent->FullName());
@@ -2365,15 +2363,15 @@ CreditDB *CreditDB::Copy()
     FnTrace("CreditDB::Copy()");
     CreditDB *newdb;
     Credit   *credit = credit_list.Head();
-    Credit   *crednext = nullptr; // REFACTOR: NULL -> nullptr for modern C++
+    Credit   *crednext = nullptr;
 
     newdb = new CreditDB(db_type);
-    if (newdb != nullptr) // REFACTOR: NULL -> nullptr for modern C++
+    if (newdb != nullptr)
     {
         strcpy(newdb->fullpath, fullpath);
         newdb->last_card_id = last_card_id;
 
-        while (credit != nullptr) // REFACTOR: NULL -> nullptr for modern C++
+        while (credit != nullptr)
         {
             crednext = credit->next;
             newdb->credit_list.AddToTail(credit);
@@ -2417,7 +2415,7 @@ int CreditDB::Write(OutputDataFile &outfile)
 
     outfile.Write(CREDIT_CARD_VERSION);
     outfile.Write(count);
-    while (credit != nullptr) // REFACTOR: NULL -> nullptr for modern C++
+    while (credit != nullptr)
     {
         if (credit->IsEmpty() == 0)
             credit->Write(outfile, CREDIT_CARD_VERSION);
@@ -2460,7 +2458,7 @@ int CreditDB::Load(const char* path)
     int version;  // a throwaway for infile; we save version manually so that
                   // Read() and Write() don't have to wonder.
 
-    if (path != nullptr) // REFACTOR: NULL -> nullptr for modern C++
+    if (path != nullptr)
         strcpy(fullpath, path);
 
     if (fullpath[0] != '\0')
@@ -2482,7 +2480,7 @@ int CreditDB::Add(Credit *credit)
     FnTrace("CreditDB::Add(Credit)");
     int retval = 0;
 
-    if (credit != nullptr) // REFACTOR: NULL -> nullptr for modern C++
+    if (credit != nullptr)
     {
         if (credit->card_id == 0)
         {
@@ -2546,10 +2544,10 @@ int CreditDB::Remove(int id)
     int retval = 0;
     Credit *credit = credit_list.Head();
 
-    while (credit != nullptr && credit->card_id != id) // REFACTOR: NULL -> nullptr for modern C++
+    while (credit != nullptr && credit->card_id != id)
         credit = credit->next;
 
-    if (credit != nullptr && credit->card_id == id) // REFACTOR: NULL -> nullptr for modern C++
+    if (credit != nullptr && credit->card_id == id)
     {
         credit_list.Remove(credit);
     }
@@ -2561,7 +2559,7 @@ int CreditDB::MakeReport(Terminal *term, Report *report, LayoutZone *rzone)
 {
     FnTrace("CreditDB::MakeReport()");
     int retval = 0;
-    Credit *credit = nullptr; // REFACTOR: NULL -> nullptr for modern C++
+    Credit *credit = nullptr;
     int color = COLOR_DEFAULT;
     int spacing = rzone->ColumnSpacing(term, 4);
     int indent = 0;
@@ -2575,7 +2573,7 @@ int CreditDB::MakeReport(Terminal *term, Report *report, LayoutZone *rzone)
     else
     {
         credit = credit_list.Head();
-        while (credit != nullptr) // REFACTOR: NULL -> nullptr for modern C++
+        while (credit != nullptr)
         {
             indent = 0;
             report->TextPosL(indent, credit->PAN(settings->show_entire_cc_num));
@@ -2600,12 +2598,12 @@ int CreditDB::MakeReport(Terminal *term, Report *report, LayoutZone *rzone)
 Credit *CreditDB::FindByRecord(Terminal *term, int record)
 {
     FnTrace("CreditDB::FindByRecord()");
-    Credit *retval = nullptr; // REFACTOR: NULL -> nullptr for modern C++
+    Credit *retval = nullptr;
     Credit *curr = credit_list.Head();
     int count = 0;
     int done = 0;
     
-    while (curr != nullptr && done == 0) // REFACTOR: NULL -> nullptr for modern C++
+    while (curr != nullptr && done == 0)
     {
         if (count == record)
         {
@@ -2629,7 +2627,7 @@ int CreditDB::HaveOpenCards()
     int retval = 0;
     Credit *curr = credit_list.Head();
 
-    while (curr != nullptr && retval == 0) // REFACTOR: NULL -> nullptr for modern C++
+    while (curr != nullptr && retval == 0)
     {
         if (curr->Status() != CCAUTH_VOID && curr->Status() != CCAUTH_REFUND)
             retval = 1;
@@ -2846,11 +2844,11 @@ CCSettle::CCSettle()
 {
     FnTrace("CCSettle::CCSettle()");
 
-    next = nullptr; // REFACTOR: NULL -> nullptr for modern C++
-    fore = nullptr; // REFACTOR: NULL -> nullptr for modern C++
+    next = nullptr;
+    fore = nullptr;
     filepath[0] = '\0';
-    current = nullptr; // REFACTOR: NULL -> nullptr for modern C++
-    archive = nullptr; // REFACTOR: NULL -> nullptr for modern C++
+    current = nullptr;
+    archive = nullptr;
     Clear();
 }
 
@@ -2858,18 +2856,18 @@ CCSettle::CCSettle(const char* fullpath)
 {
     FnTrace("CCSettle::CCSettle()");
 
-    next = nullptr; // REFACTOR: NULL -> nullptr for modern C++
-    fore = nullptr; // REFACTOR: NULL -> nullptr for modern C++
+    next = nullptr;
+    fore = nullptr;
     strcpy(filepath, fullpath);
-    current = nullptr; // REFACTOR: NULL -> nullptr for modern C++
-    archive = nullptr; // REFACTOR: NULL -> nullptr for modern C++
+    current = nullptr;
+    archive = nullptr;
     Clear();
 }
 
 CCSettle::~CCSettle()
 {
     FnTrace("CCSettle::~CCSettle()");
-    if (next != nullptr) // REFACTOR: NULL -> nullptr for modern C++
+    if (next != nullptr)
         delete next;
 }
 
@@ -2880,7 +2878,7 @@ int CCSettle::Next(Terminal *term)
     int loops = 0;
     Settings *settings = term->GetSettings();
 
-    if (current == nullptr) // REFACTOR: NULL -> nullptr for modern C++
+    if (current == nullptr)
     {
         current = this;
     }
@@ -2891,11 +2889,11 @@ int CCSettle::Next(Terminal *term)
         // avoid grabbing NULLs.
         while (loops < MAX_LOOPS)
         {
-            if (current != nullptr && current->next != nullptr) // REFACTOR: NULL -> nullptr for modern C++
+            if (current != nullptr && current->next != nullptr)
                 current = current->next;
             else
             { // search archives
-                if (archive == nullptr) // REFACTOR: NULL -> nullptr for modern C++
+                if (archive == nullptr)
                 {
                     archive = MasterSystem->ArchiveList();
                     if (archive && archive->loaded == 0)
@@ -2908,15 +2906,15 @@ int CCSettle::Next(Terminal *term)
                         archive = archive->next;
                         if (archive && archive->loaded == 0)
                             archive->LoadPacked(settings);
-                    } while (archive != nullptr && archive->cc_settle_results == nullptr); // REFACTOR: NULL -> nullptr for modern C++
+                    } while (archive != nullptr && archive->cc_settle_results == nullptr);
                 }
 
-                if (archive != nullptr) // REFACTOR: NULL -> nullptr for modern C++
+                if (archive != nullptr)
                     current = archive->cc_settle_results;
                 else
                     current = this;
             }
-            loops += ((current != nullptr) ? MAX_LOOPS : 1); // REFACTOR: NULL -> nullptr for modern C++
+            loops += ((current != nullptr) ? MAX_LOOPS : 1);
         }
     }
 
@@ -2930,7 +2928,7 @@ int CCSettle::Fore(Terminal *term)
     int loops = 0;
     Settings *settings = term->GetSettings();
 
-    if (current == nullptr) // REFACTOR: NULL -> nullptr for modern C++
+    if (current == nullptr)
     {
         current = this;
     }
@@ -2941,11 +2939,11 @@ int CCSettle::Fore(Terminal *term)
         // avoid grabbing NULLs.
         while (loops < MAX_LOOPS)
         {
-            if (current != nullptr && current->fore != nullptr) // REFACTOR: NULL -> nullptr for modern C++
+            if (current != nullptr && current->fore != nullptr)
                 current = current->fore;
             else
             { // search archives
-                if (archive == nullptr) // REFACTOR: NULL -> nullptr for modern C++
+                if (archive == nullptr)
                 {
                     archive = MasterSystem->ArchiveListEnd();
                     if (archive && archive->loaded == 0)
@@ -2958,18 +2956,18 @@ int CCSettle::Fore(Terminal *term)
                         archive = archive->fore;
                         if (archive && archive->loaded == 0)
                             archive->LoadPacked(settings);
-                    } while (archive != nullptr && archive->cc_settle_results == nullptr); // REFACTOR: NULL -> nullptr for modern C++
+                    } while (archive != nullptr && archive->cc_settle_results == nullptr);
                 }
 
-                if (archive != nullptr) // REFACTOR: NULL -> nullptr for modern C++
+                if (archive != nullptr)
                     current = archive->cc_settle_results;
                 else
                     current = this;
 
-                while (current!= nullptr && current->next != nullptr) // REFACTOR: NULL -> nullptr for modern C++
+                while (current!= nullptr && current->next != nullptr)
                     current = current->next;
             }
-            loops += ((current != nullptr) ? MAX_LOOPS : 1); // REFACTOR: NULL -> nullptr for modern C++
+            loops += ((current != nullptr) ? MAX_LOOPS : 1);
         }
     }
 
@@ -2981,7 +2979,7 @@ CCSettle *CCSettle::Last()
     FnTrace("CCSettle:Last()");
     CCSettle *retval = this;
 
-    while (retval->next != nullptr) // REFACTOR: NULL -> nullptr for modern C++
+    while (retval->next != nullptr)
         retval = retval->next;
 
     return retval;
@@ -2991,12 +2989,12 @@ int CCSettle::Add(Terminal *term, const char* message)
 {
     FnTrace("CCSettle::Add(Terminal)");
     int retval = 0;
-    CCSettle *newsettle = nullptr; // REFACTOR: NULL -> nullptr for modern C++
-    CCSettle *curr = nullptr; // REFACTOR: NULL -> nullptr for modern C++
+    CCSettle *newsettle = nullptr;
+    CCSettle *curr = nullptr;
 
     if (result.empty())
     {
-        if (message != nullptr) // REFACTOR: NULL -> nullptr for modern C++
+        if (message != nullptr)
         {
             result.Set("Batch Settle Failed");
             errormsg.Set(message);
@@ -3008,7 +3006,7 @@ int CCSettle::Add(Terminal *term, const char* message)
     else
     {
         newsettle = new CCSettle();
-        if (message != nullptr) // REFACTOR: NULL -> nullptr for modern C++
+        if (message != nullptr)
         {
             newsettle->result.Set("Batch Settle Failed");
             newsettle->errormsg.Set(message);
@@ -3017,7 +3015,7 @@ int CCSettle::Add(Terminal *term, const char* message)
             newsettle->ReadResults(term);
         // Add to tail
         curr = this;
-        while (curr->next != nullptr) // REFACTOR: NULL -> nullptr for modern C++
+        while (curr->next != nullptr)
             curr = curr->next;
         curr->next = newsettle;
         newsettle->fore = curr;
@@ -3036,15 +3034,15 @@ int CCSettle::Add(Check *check)
     FnTrace("CCSettle::Add(Check)");
     int retval = 1;
     SubCheck *subcheck = check->SubList();
-    Payment *payment = nullptr; // REFACTOR: NULL -> nullptr for modern C++
-    Credit *credit = nullptr; // REFACTOR: NULL -> nullptr for modern C++
+    Payment *payment = nullptr;
+    Credit *credit = nullptr;
 
-    while (subcheck != nullptr) // REFACTOR: NULL -> nullptr for modern C++
+    while (subcheck != nullptr)
     {
         payment = subcheck->PaymentList();
-        while (payment != nullptr) // REFACTOR: NULL -> nullptr for modern C++
+        while (payment != nullptr)
         {
-            if (payment->credit != nullptr) // REFACTOR: NULL -> nullptr for modern C++
+            if (payment->credit != nullptr)
             {
                 credit = payment->credit;
                 if (credit->CardType() == CARD_TYPE_DEBIT)
@@ -3120,7 +3118,7 @@ CCSettle *CCSettle::Copy()
 
     newsettle->settle_date.Set(settle_date);
 
-    if (next != nullptr) // REFACTOR: NULL -> nullptr for modern C++
+    if (next != nullptr)
         newsettle->next = next->Copy();
 
     return newsettle;

--- a/main/credit.hh
+++ b/main/credit.hh
@@ -18,7 +18,7 @@
  * Credit/charge card verification/authorization
  */
 
-#pragma once  // REFACTOR: Replaced #ifndef _CREDIT_HH guard with modern pragma once
+#pragma once
 
 #include "list_utility.hh"
 #include "printer.hh"

--- a/main/customer.hh
+++ b/main/customer.hh
@@ -18,7 +18,7 @@
  * Implementation of customer infomation module
  */
 
-#pragma once  // REFACTOR: Replaced #ifndef _CUSTOMER_HH guard with modern pragma once
+#pragma once
 
 #include "list_utility.hh"
 #include "utility.hh"
@@ -96,22 +96,22 @@ public:
     virtual int          Type() { return type; }
     virtual int          CustomerID() { return id; }
     virtual int          Guests(int set = -1);
-    virtual const genericChar* LastName(const char* set = nullptr);        // REFACTOR: Changed NULL to nullptr for modern C++
-    virtual const genericChar* FirstName(const char* set = nullptr);       // REFACTOR: Changed NULL to nullptr for modern C++
-    virtual const genericChar* Company(const char* set = nullptr);         // REFACTOR: Changed NULL to nullptr for modern C++
-    virtual const genericChar* PhoneNumber(const char* set = nullptr);     // REFACTOR: Changed NULL to nullptr for modern C++
-    virtual const genericChar* Extension(const char* set = nullptr);       // REFACTOR: Changed NULL to nullptr for modern C++
-    virtual const genericChar* Address(const char* set = nullptr);         // REFACTOR: Changed NULL to nullptr for modern C++
-    virtual const genericChar* Address2(const char* set = nullptr);        // REFACTOR: Changed NULL to nullptr for modern C++
-    virtual const genericChar* CrossStreet(const char* set = nullptr);     // REFACTOR: Changed NULL to nullptr for modern C++
-    virtual const genericChar* City(const char* set = nullptr);            // REFACTOR: Changed NULL to nullptr for modern C++
-    virtual const genericChar* State(const char* set = nullptr);           // REFACTOR: Changed NULL to nullptr for modern C++
-    virtual const genericChar* Postal(const char* set = nullptr);          // REFACTOR: Changed NULL to nullptr for modern C++
-    virtual const genericChar* License(const char* set = nullptr);         // REFACTOR: Changed NULL to nullptr for modern C++
-    virtual const genericChar* CCNumber(const char* set = nullptr);        // REFACTOR: Changed NULL to nullptr for modern C++
-    virtual const genericChar* CCExpire(const char* set = nullptr);        // REFACTOR: Changed NULL to nullptr for modern C++
-    virtual const genericChar* Comment(const char* set = nullptr);         // REFACTOR: Changed NULL to nullptr for modern C++
-    virtual const genericChar* Vehicle(const char* set = nullptr);         // REFACTOR: Changed NULL to nullptr for modern C++
+    virtual const genericChar* LastName(const char* set = nullptr);
+    virtual const genericChar* FirstName(const char* set = nullptr);
+    virtual const genericChar* Company(const char* set = nullptr);
+    virtual const genericChar* PhoneNumber(const char* set = nullptr);
+    virtual const genericChar* Extension(const char* set = nullptr);
+    virtual const genericChar* Address(const char* set = nullptr);
+    virtual const genericChar* Address2(const char* set = nullptr);
+    virtual const genericChar* CrossStreet(const char* set = nullptr);
+    virtual const genericChar* City(const char* set = nullptr);
+    virtual const genericChar* State(const char* set = nullptr);
+    virtual const genericChar* Postal(const char* set = nullptr);
+    virtual const genericChar* License(const char* set = nullptr);
+    virtual const genericChar* CCNumber(const char* set = nullptr);
+    virtual const genericChar* CCExpire(const char* set = nullptr);
+    virtual const genericChar* Comment(const char* set = nullptr);
+    virtual const genericChar* Vehicle(const char* set = nullptr);
     virtual int          Search(const char* word);
 };
 
@@ -137,7 +137,7 @@ public:
     CustomerInfo *CustomerListEnd()               { return customers.Tail(); }
 
     int           Count();
-    int           Save(const genericChar* filepath = nullptr);  // REFACTOR: Changed NULL to nullptr for modern C++
+    int           Save(const genericChar* filepath = nullptr);
     int           Save(CustomerInfo *customer);
     int           Load(const genericChar* filepath);
     CustomerInfo *NewCustomer(int customer_type);

--- a/main/drawer.hh
+++ b/main/drawer.hh
@@ -18,7 +18,7 @@
  * Drawer balance, report, use classes
  */
 
-#pragma once  // REFACTOR: Replaced #ifndef _DRAWER_HH guard with modern pragma once
+#pragma once
 
 #include "utility.hh"
 #include "list_utility.hh"
@@ -85,7 +85,7 @@ public:
     // Member Functions
     int   Read(InputDataFile &df, int version);
     int   Write(OutputDataFile &df, int version);
-    genericChar* Description(Settings *s, genericChar* str = nullptr);  // REFACTOR: Changed NULL to nullptr for modern C++
+    genericChar* Description(Settings *s, genericChar* str = nullptr);
 };
 
 class Drawer
@@ -96,7 +96,7 @@ class Drawer
 public:
     Drawer    *next;
     Drawer    *fore;      // linked list pointers
-    Archive   *archive;          // parent archive (nullptr if current drawer)  // REFACTOR: Changed NULL to nullptr for modern C++
+    Archive   *archive;          // parent archive (nullptr if current drawer)
     TimeInfo   start_time;       // time of drawer initialization
     TimeInfo   pull_time;        // time of drawer pull
     TimeInfo   balance_time;     // time of drawer balance

--- a/main/employee.hh
+++ b/main/employee.hh
@@ -18,7 +18,7 @@
  * Employee information classes
  */
 
-#pragma once  // REFACTOR: Replaced #ifndef _EMPLOYEE_HH guard with modern pragma once
+#pragma once
 
 #include "utility.hh"
 #include "list_utility.hh"
@@ -164,7 +164,7 @@ public:
     int UsePassword(Settings *s);
     // does user use passwords?
 
-    int IsTraining(Settings *s = nullptr) { return training; }  // REFACTOR: Changed NULL to nullptr for modern C++
+    int IsTraining(Settings *s = nullptr) { return training; }
     int CanEnterSystem(Settings *s) { return Security(s) & SECURITY_TABLES; }
     int CanOrder(Settings *s)       { return Security(s) & SECURITY_ORDER; }
     int CanSettle(Settings *s)      { return Security(s) & SECURITY_SETTLE; }

--- a/main/expense.hh
+++ b/main/expense.hh
@@ -28,7 +28,7 @@
 //  for one value per drawer.  Thus the current method which may, in
 //  the end, not work.
 
-#pragma once  // REFACTOR: Replaced #ifndef _EXPENSE_HH guard with modern pragma once
+#pragma once
 
 #include "list_utility.hh"
 #include "utility.hh"

--- a/main/inventory.cc
+++ b/main/inventory.cc
@@ -315,8 +315,8 @@ UnitAmount &UnitAmount::operator-= (UnitAmount &ua)
 // Constructor
 Product::Product()
 {
-    next = nullptr;  // REFACTOR: Changed NULL to nullptr for modern C++ - eliminates ambiguous NULL macro
-    fore = nullptr;  // REFACTOR: Changed NULL to nullptr for modern C++ - eliminates ambiguous NULL macro
+    next = nullptr;
+    fore = nullptr;
     cost = 0;
     id   = 0;
 }
@@ -363,8 +363,8 @@ int Product::DoesVendorHave(int vendor_id)
 // Constructor
 RecipePart::RecipePart()
 {
-    next    = nullptr;  // REFACTOR: Changed NULL to nullptr for modern C++
-    fore    = nullptr;  // REFACTOR: Changed NULL to nullptr for modern C++
+    next    = nullptr;
+    fore    = nullptr;
     part_id = 0;
 }
 
@@ -403,8 +403,8 @@ int RecipePart::Write(OutputDataFile &df, int version)
 // Constructor
 Recipe::Recipe()
 {
-    next              = nullptr;  // REFACTOR: Changed NULL to nullptr for modern C++
-    fore              = nullptr;  // REFACTOR: Changed NULL to nullptr for modern C++
+    next              = nullptr;
+    fore              = nullptr;
     prepare_time      = 0;
     id                = 0;
     in_menu           = 0;
@@ -535,8 +535,8 @@ int Recipe::RemoveIngredient(int part_id, UnitAmount &ua)
 // Constructor
 Vendor::Vendor()
 {
-    next = nullptr;  // REFACTOR: Changed NULL to nullptr for modern C++ - eliminates ambiguous NULL macro
-    fore = nullptr;  // REFACTOR: Changed NULL to nullptr for modern C++ - eliminates ambiguous NULL macro
+    next = nullptr;
+    fore = nullptr;
     id   = 0;
 }
 

--- a/main/inventory.hh
+++ b/main/inventory.hh
@@ -18,7 +18,7 @@
  * Raw Product, Receipe & Vendor data bases
  */
 
-#pragma once  // REFACTOR: Replaced #ifndef _INVENTORY_HH guard with modern pragma once
+#pragma once
 
 #include "utility.hh"
 #include "list_utility.hh"
@@ -72,8 +72,8 @@ public:
     int   Read(InputDataFile &df, int version);
     int   Write(OutputDataFile &df, int version);
     int   Convert(int new_type);
-    genericChar* Description( char* str = nullptr);  // REFACTOR: Changed NULL to nullptr for modern C++
-    genericChar* Measurement( char* str = nullptr); // REFACTOR: Changed NULL to nullptr for modern C++
+    genericChar* Description( char* str = nullptr);
+    genericChar* Measurement( char* str = nullptr);
 
     UnitAmount &operator *= (Flt a) {
         amount *= a; return *this; }
@@ -260,7 +260,7 @@ public:
     int Remove(StockEntry *se);
     int Remove(Invoice *in);
     int Purge();
-    int Load(const char* file = nullptr);  // REFACTOR: Changed NULL to nullptr for modern C++
+    int Load(const char* file = nullptr);
     int Save();
     int Total();
     Invoice *NewInvoice(int vendor_id);

--- a/main/labels.cc
+++ b/main/labels.cc
@@ -26,6 +26,31 @@
 #include "drawer_zone.hh"
 #include "cdu.hh"
 
+// Font constants for the UI dropdown (avoid header conflicts)
+#define FONT_DEJAVU_14    20
+#define FONT_DEJAVU_16    21
+#define FONT_DEJAVU_18    22
+#define FONT_DEJAVU_20    23
+#define FONT_DEJAVU_24    24
+#define FONT_DEJAVU_28    25
+#define FONT_DEJAVU_14B   26
+#define FONT_DEJAVU_16B   27
+#define FONT_DEJAVU_18B   28
+#define FONT_DEJAVU_20B   29
+#define FONT_DEJAVU_24B   30
+#define FONT_DEJAVU_28B   31
+
+#define FONT_MONO_14      32
+#define FONT_MONO_16      33
+#define FONT_MONO_18      34
+#define FONT_MONO_20      35
+#define FONT_MONO_24      36
+#define FONT_MONO_14B     37
+#define FONT_MONO_16B     38
+#define FONT_MONO_18B     39
+#define FONT_MONO_20B     40
+#define FONT_MONO_24B     41
+
 #ifdef DMALLOC
 #include <dmalloc.h>
 #endif
@@ -261,16 +286,49 @@ int ColorValue[] = {
 
 // Updated font choices to provide better progression for scalable fonts in Button Properties Dialog
 // Moved away from legacy bitmapped font limitations to more appropriate scalable font sizes
+// Added modern POS fonts for better readability and professional appearance
 const genericChar* FontName[] = {
-    "Default", "Times 14", "Times 14 Bold", "Times 18", "Times 18 Bold",
+    "Default", 
+    
+    // Legacy Times fonts (maintained for compatibility)
+    "Times 14", "Times 14 Bold", "Times 18", "Times 18 Bold",
     "Times 20", "Times 20 Bold", "Times 24", "Times 24 Bold",
-    "Times 34", "Times 34 Bold", "Courier 18", "Courier 18 Bold",
-    "Courier 20", "Courier 20 Bold", nullptr};
+    "Times 34", "Times 34 Bold", 
+    
+    // Legacy Courier fonts (maintained for compatibility)
+    "Courier 18", "Courier 18 Bold", "Courier 20", "Courier 20 Bold", 
+    
+    // Modern DejaVu Sans fonts - Recommended for POS interfaces
+    "DejaVu Sans 14", "DejaVu Sans 16", "DejaVu Sans 18", "DejaVu Sans 20",
+    "DejaVu Sans 24", "DejaVu Sans 28",
+    "DejaVu Sans 14 Bold", "DejaVu Sans 16 Bold", "DejaVu Sans 18 Bold", 
+    "DejaVu Sans 20 Bold", "DejaVu Sans 24 Bold", "DejaVu Sans 28 Bold",
+    
+    // Monospace fonts - Perfect for prices and data alignment
+    "Monospace 14", "Monospace 16", "Monospace 18", "Monospace 20", "Monospace 24",
+    "Monospace 14 Bold", "Monospace 16 Bold", "Monospace 18 Bold", 
+    "Monospace 20 Bold", "Monospace 24 Bold", nullptr};
+    
 int FontValue[] = {
-    FONT_DEFAULT, FONT_TIMES_14, FONT_TIMES_14B, FONT_TIMES_18, FONT_TIMES_18B,
+    FONT_DEFAULT, 
+    
+    // Legacy Times fonts
+    FONT_TIMES_14, FONT_TIMES_14B, FONT_TIMES_18, FONT_TIMES_18B,
     FONT_TIMES_20, FONT_TIMES_20B, FONT_TIMES_24, FONT_TIMES_24B,
-    FONT_TIMES_34, FONT_TIMES_34B, FONT_COURIER_18, FONT_COURIER_18B,
-    FONT_COURIER_20, FONT_COURIER_20B, -1};
+    FONT_TIMES_34, FONT_TIMES_34B, 
+    
+    // Legacy Courier fonts
+    FONT_COURIER_18, FONT_COURIER_18B, FONT_COURIER_20, FONT_COURIER_20B,
+    
+    // Modern DejaVu Sans fonts
+    FONT_DEJAVU_14, FONT_DEJAVU_16, FONT_DEJAVU_18, FONT_DEJAVU_20,
+    FONT_DEJAVU_24, FONT_DEJAVU_28,
+    FONT_DEJAVU_14B, FONT_DEJAVU_16B, FONT_DEJAVU_18B, 
+    FONT_DEJAVU_20B, FONT_DEJAVU_24B, FONT_DEJAVU_28B,
+    
+    // Monospace fonts
+    FONT_MONO_14, FONT_MONO_16, FONT_MONO_18, FONT_MONO_20, FONT_MONO_24,
+    FONT_MONO_14B, FONT_MONO_16B, FONT_MONO_18B, FONT_MONO_20B, FONT_MONO_24B, -1};
 
 const genericChar* IndexName[] = {
     "General", "Breakfast", "Brunch", "Lunch",

--- a/main/labor.hh
+++ b/main/labor.hh
@@ -18,7 +18,7 @@
  * Work scheduling & time clock classes
  */
 
-#pragma once  // REFACTOR: Replaced #ifndef _LABOR_HH guard with modern pragma once
+#pragma once
 
 #include "utility.hh"
 #include "list_utility.hh"

--- a/main/license_hash.hh
+++ b/main/license_hash.hh
@@ -1,4 +1,4 @@
-#pragma once  // REFACTOR: Replaced #ifndef _LICENSE_HASH_HH guard with modern pragma once
+#pragma once
 
 /*
  * Copyright ViewTouch, Inc., 1995, 1996, 1997, 1998  

--- a/main/manager.hh
+++ b/main/manager.hh
@@ -1,4 +1,4 @@
-#pragma once  // REFACTOR: Replaced #ifndef VT_MANAGER_HH guard with modern pragma once
+#pragma once
 
 /*
  * Copyright ViewTouch, Inc., 1995, 1996, 1997, 1998  

--- a/main/printer.hh
+++ b/main/printer.hh
@@ -18,7 +18,7 @@
  * Definition of printer device class
  */
 
-#pragma once  // REFACTOR: Replaced #ifndef _PRINTER_HH guard with modern pragma once
+#pragma once
 
 #include "utility.hh"
 

--- a/main/report.hh
+++ b/main/report.hh
@@ -18,7 +18,7 @@
  * layout & formating of report information
  */
 
-#pragma once  // REFACTOR: Replaced #ifndef _REPORT_HH guard with modern pragma once
+#pragma once
 
 #include "utility.hh"
 #include "terminal.hh"

--- a/main/sales.hh
+++ b/main/sales.hh
@@ -18,7 +18,7 @@
  * Definitions of sale item classes
  */
 
-#pragma once  // REFACTOR: Replaced #ifndef _SALES_HH guard with modern pragma once
+#pragma once
 
 #include "utility.hh"
 #include "list_utility.hh"
@@ -193,7 +193,7 @@ public:
     int   price_type;     // price type (see above)
 
     // Constructor
-    SalesItem(const char* name = nullptr);  // REFACTOR: Changed NULL to nullptr for modern C++
+    SalesItem(const char* name = nullptr);
 
     // Member Functions
     Component *ComponentList() { return component_list.Head(); }

--- a/main/settings.cc
+++ b/main/settings.cc
@@ -50,10 +50,7 @@
 #define CONFIG_FEES_FILE VIEWTOUCH_PATH "/dat/conf/fees.ini"
 #define CONFIG_FASTFOOD_FILE VIEWTOUCH_PATH "/dat/conf/fastfood.ini"
 
-#include <filesystem>
-#include <iostream> // temp
-
-namespace fs = std::filesystem;
+#include <sys/stat.h>       // for mkdir and stat functions
 
 /*********************************************************************
  * Global Data
@@ -2391,12 +2388,13 @@ int Settings::Save()
 
     // save settings to config files.  eventually all settings should be
     // written to config files instead of .dat files.
-    if (!fs::is_directory(CONFIG_DIR))
+    struct stat st;
+    if (stat(CONFIG_DIR, &st) != 0 || !S_ISDIR(st.st_mode))
     {
         std::cerr << "Config directory does not exist: '"
             << CONFIG_DIR << "' creating it" << std::endl;
-        fs::create_directory(CONFIG_DIR);
-        fs::permissions(CONFIG_DIR, fs::perms::all); // be sure read/write/execute flags are set
+        mkdir(CONFIG_DIR, 0755);
+        chmod(CONFIG_DIR, 0755); // set read/write/execute permissions
     }
     {
         using namespace confmap;

--- a/main/system.cc
+++ b/main/system.cc
@@ -737,7 +737,7 @@ int System::SetDataPath(const char* path)
     // Make sure all data directories in path are set up
     chmod(path, DIR_PERMISSIONS);
     snprintf(str, STRLENGTH, "%s/current", path);
-    EnsureFileExists(str);
+    EnsureDirExists(str);
 
     // consolidate checks & drawers
     snprintf(tmp, STRLENGTH, "%s/checks", path);
@@ -761,44 +761,44 @@ int System::SetDataPath(const char* path)
     }
 
     snprintf(str, STRLENGTH, "%s/%s", path, ARCHIVE_DATA_DIR);
-    EnsureFileExists(str);
+    EnsureDirExists(str);
 
     snprintf(str, STRLENGTH, "%s/%s", path, LABOR_DATA_DIR);
-    EnsureFileExists(str);
+    EnsureDirExists(str);
 
     snprintf(str, STRLENGTH, "%s/%s", path, STOCK_DATA_DIR);
-    EnsureFileExists(str);
+    EnsureDirExists(str);
 
     snprintf(str, STRLENGTH, "%s/%s", path, LANGUAGE_DATA_DIR);
-    EnsureFileExists(str);
+    EnsureDirExists(str);
 
     snprintf(str, STRLENGTH, "%s/%s", path, ACCOUNTS_DATA_DIR);
-    EnsureFileExists(str);
+    EnsureDirExists(str);
 
     snprintf(str, STRLENGTH, "%s/%s", path, EXPENSE_DATA_DIR);
-    EnsureFileExists(str);
+    EnsureDirExists(str);
 
     snprintf(str, STRLENGTH, "%s/%s", path, CUSTOMER_DATA_DIR);
-    EnsureFileExists(str);
+    EnsureDirExists(str);
 
     snprintf(str, STRLENGTH, "%s/%s", path, HTML_DATA_DIR);
-    EnsureFileExists(str);
+    EnsureDirExists(str);
 
     snprintf(str, STRLENGTH, "%s/%s", path, TEXT_DATA_DIR);
-    EnsureFileExists(str);
+    EnsureDirExists(str);
 
     snprintf(str, STRLENGTH, "%s/%s", path, PAGEEXPORTS_DIR);
-    EnsureFileExists(str);
+    EnsureDirExists(str);
 
     snprintf(str, STRLENGTH, "%s/%s", path, PAGEIMPORTS_DIR);
-    EnsureFileExists(str);
+    EnsureDirExists(str);
 
     snprintf(str, STRLENGTH, "%s/%s", path, UPDATES_DATA_DIR);
-    EnsureFileExists(str);
+    EnsureDirExists(str);
 
     snprintf(str, STRLENGTH, "%s/%s", path, BACKUP_DATA_DIR);
     backup_path.Set(str);
-    EnsureFileExists(str);
+    EnsureDirExists(str);
 
     return 0;
 }

--- a/main/system.hh
+++ b/main/system.hh
@@ -18,7 +18,7 @@
  * Data storage & report generation for current/previous business days
  */
 
-#pragma once  // REFACTOR: Replaced #ifndef _SYSTEM_HH guard with modern pragma once
+#pragma once
 
 #include "tips.hh"
 #include "labor.hh"
@@ -154,7 +154,7 @@ public:
     int SetDataPath(const char* path);
     // specify directory where system data is kept
     int CheckFileUpdates();
-    genericChar* FullPath(const char* filename, genericChar* buffer = nullptr);  // REFACTOR: Changed NULL to nullptr for modern C++
+    genericChar* FullPath(const char* filename, genericChar* buffer = nullptr);
     // returns string containing full filename for system datafile
     int LoadCurrentData(const char* path);
     // loads current day's data ('current' directory)
@@ -194,9 +194,9 @@ public:
     // adds check to current data
     int Remove(Check *check);
     // removes check from current check list (doesn't delete)
-    Check *FirstCheck(Archive *archive = nullptr);                      // REFACTOR: Changed NULL to nullptr for modern C++
+    Check *FirstCheck(Archive *archive = nullptr);
     // returns first check of archive or current checks
-    int CountOpenChecks(Employee *e = nullptr);                         // REFACTOR: Changed NULL to nullptr for modern C++
+    int CountOpenChecks(Employee *e = nullptr);
     // counts open checks owned by user (or by everyone)
     int NumberStacked(const char* table, Employee *e);
     // Returns number of open checks at tables
@@ -215,7 +215,7 @@ public:
     // adds drawer to current data
     int Remove(Drawer *drawer);
     // removes drawer from current drawer list (doesn't delete)
-    Drawer *FirstDrawer(Archive *archive = nullptr);                    // REFACTOR: Changed NULL to nullptr for modern C++
+    Drawer *FirstDrawer(Archive *archive = nullptr);
     // returns first drawer of archive or current drawers
     Drawer *GetServerBank(Employee *e);
     // returns server bank for user (creates new one if needed)
@@ -229,11 +229,11 @@ public:
     // boolean - are all drawers pulled or balanced?
 
     // Exception functions
-    ItemException *FirstItemException(Archive *archive = nullptr);       // REFACTOR: Changed NULL to nullptr for modern C++
+    ItemException *FirstItemException(Archive *archive = nullptr);
     // returns first item exception of archive or current exceptions
-    TableException *FirstTableException(Archive *archive = nullptr);     // REFACTOR: Changed NULL to nullptr for modern C++
+    TableException *FirstTableException(Archive *archive = nullptr);
     // returns first table exception of archive or current exceptions
-    RebuildException *FirstRebuildException(Archive *archive = nullptr); // REFACTOR: Changed NULL to nullptr for modern C++
+    RebuildException *FirstRebuildException(Archive *archive = nullptr);
     // returns first rebuild exception of archive or current exceptions
 
     // report functions (see system_report.cc)

--- a/main/tips.cc
+++ b/main/tips.cc
@@ -38,8 +38,8 @@
 TipEntry::TipEntry()
 {
     FnTrace("TipEntry::TipEntry()");
-    next            = nullptr;  // REFACTOR: Changed NULL to nullptr for modern C++
-    fore            = nullptr;  // REFACTOR: Changed NULL to nullptr for modern C++
+    next            = nullptr;
+    fore            = nullptr;
     user_id         = 0;
     amount          = 0;
     previous_amount = 0;
@@ -71,8 +71,8 @@ TipEntry *TipEntry::Copy()
 {
     FnTrace("TipEntry::Copy()");
     TipEntry *te = new TipEntry;
-    if (te == nullptr)  // REFACTOR: Changed NULL to nullptr for modern C++
-        return nullptr;  // REFACTOR: Changed NULL to nullptr for modern C++
+    if (te == nullptr)
+        return nullptr;
 
     te->user_id = user_id;
     te->amount  = amount;
@@ -84,7 +84,7 @@ int TipEntry::Count()
 {
     FnTrace("TipEntry::Count()");
     int count = 1;
-    for (TipEntry *te = next; te != nullptr; te = te->next)  // REFACTOR: Changed NULL to nullptr for modern C++
+    for (TipEntry *te = next; te != nullptr; te = te->next)
         ++count;
     return count;
 }
@@ -94,7 +94,7 @@ int TipEntry::Count()
 TipDB::TipDB()
 {
     FnTrace("TipDB::TipDB()");
-    archive        = nullptr;  // REFACTOR: Changed NULL to nullptr for modern C++
+    archive        = nullptr;
     total_paid     = 0;
     total_held     = 0;
     total_previous = 0;
@@ -104,7 +104,7 @@ TipDB::TipDB()
 int TipDB::Add(TipEntry *te)
 {
     FnTrace("TipDB::Add()");
-    if (te == nullptr)  // REFACTOR: Changed NULL to nullptr for modern C++
+    if (te == nullptr)
         return 1;
 
     // search for previous entry for user
@@ -143,30 +143,30 @@ int TipDB::Purge()
 TipEntry *TipDB::FindByUser(int id)
 {
     FnTrace("TipDB::FindByUser()");
-    for (TipEntry *te = TipList(); te != nullptr; te = te->next)  // REFACTOR: Changed NULL to nullptr for modern C++
+    for (TipEntry *te = TipList(); te != nullptr; te = te->next)
     {
         if (te->user_id == id)
             return te;
     }
-    return nullptr;  // REFACTOR: Changed NULL to nullptr for modern C++
+    return nullptr;
 }
 
 TipEntry *TipDB::FindByRecord(int record, Employee *e)
 {
     FnTrace("TipDB::FindByRecord()");
     if (record < 0)
-        return nullptr;  // REFACTOR: Changed NULL to nullptr for modern C++
+        return nullptr;
 
-    for (TipEntry *te = TipList(); te != nullptr; te = te->next)  // REFACTOR: Changed NULL to nullptr for modern C++
+    for (TipEntry *te = TipList(); te != nullptr; te = te->next)
     {
-        if (e == nullptr || te->user_id == e->id)  // REFACTOR: Changed NULL to nullptr for modern C++
+        if (e == nullptr || te->user_id == e->id)
         {
             if (record <= 0)
                 return te;
             --record;
         }
     }
-    return nullptr;  // REFACTOR: Changed NULL to nullptr for modern C++
+    return nullptr;
 }
 
 int TipDB::CaptureTip(int user_id, int amount)
@@ -221,7 +221,7 @@ int TipDB::PayoutTip(int user_id, int amount)
 {
     FnTrace("TipDB::PayoutTip()");
     TipEntry *te = FindByUser(user_id);
-    if (te == nullptr || te->amount <= 0)  // REFACTOR: Changed NULL to nullptr for modern C++
+    if (te == nullptr || te->amount <= 0)
         return 1;  // no captured tip to payout
 
     te->amount -= amount;
@@ -246,9 +246,9 @@ int TipDB::Calculate(Settings *s, TipDB *previous,
     }
 
     // figure today's tips
-    for (Check *c = check_list; c != nullptr; c = c->next)  // REFACTOR: Changed NULL to nullptr for modern C++
+    for (Check *c = check_list; c != nullptr; c = c->next)
     {
-        for (SubCheck *sc = c->SubList(); sc != nullptr; sc = sc->next)  // REFACTOR: Changed NULL to nullptr for modern C++
+        for (SubCheck *sc = c->SubList(); sc != nullptr; sc = sc->next)
         {
             int tips = sc->TotalTip();
             if (tips != 0)
@@ -257,9 +257,9 @@ int TipDB::Calculate(Settings *s, TipDB *previous,
     }
 
     // subract amount paid out
-    for (Drawer *d = drawer_list; d != nullptr; d = d->next)  // REFACTOR: Changed NULL to nullptr for modern C++
+    for (Drawer *d = drawer_list; d != nullptr; d = d->next)
     {
-        for (DrawerPayment *dp = d->PaymentList(); dp != nullptr; dp = dp->next)  // REFACTOR: Changed NULL to nullptr for modern C++
+        for (DrawerPayment *dp = d->PaymentList(); dp != nullptr; dp = dp->next)
         {
             if (dp->tender_type == TENDER_PAID_TIP)
                 PayoutTip(dp->target_id, dp->amount);
@@ -274,7 +274,7 @@ int TipDB::Copy(TipDB *db)
     FnTrace("TipDB::Copy()");
     Purge();
 
-    for (TipEntry *te = db->TipList(); te != nullptr; te = te->next)  // REFACTOR: Changed NULL to nullptr for modern C++
+    for (TipEntry *te = db->TipList(); te != nullptr; te = te->next)
         Add(te->Copy());
     return 0;
 }
@@ -286,7 +286,7 @@ int TipDB::Total()
     total_held     = 0;
     total_previous = 0;
 
-    for (TipEntry *te = TipList(); te != nullptr; te = te->next)  // REFACTOR: Changed NULL to nullptr for modern C++
+    for (TipEntry *te = TipList(); te != nullptr; te = te->next)
     {
         if (te->paid > 0)
             total_paid += te->paid;
@@ -303,21 +303,21 @@ void TipDB::ClearHeld()
     FnTrace("TipDB::ClearHeld()");
     total_held     = 0;
 
-    for (TipEntry *te = TipList(); te != nullptr; te = te->next)  // REFACTOR: Changed NULL to nullptr for modern C++
+    for (TipEntry *te = TipList(); te != nullptr; te = te->next)
         te->amount = 0;
 }
 
 int TipDB::PaidReport(Terminal *t, Report *r)
 {
     FnTrace("TipDB::PaidReport()");
-    if (r == nullptr)  // REFACTOR: Changed NULL to nullptr for modern C++
+    if (r == nullptr)
         return 1;
 
     r->TextC("Tips Paid Report");
     r->NewLine(2);
 
     int total = 0;
-    for (TipEntry *te = TipList(); te != nullptr; te = te->next)  // REFACTOR: Changed NULL to nullptr for modern C++
+    for (TipEntry *te = TipList(); te != nullptr; te = te->next)
     {
         if (te->paid > 0)
         {
@@ -339,7 +339,7 @@ int TipDB::PaidReport(Terminal *t, Report *r)
 int TipDB::PayoutReceipt(Terminal *t, Employee *e, int amount, Report *r)
 {
     FnTrace("TipDB::PayoutReceipt()");
-    if (r == nullptr || e == nullptr || amount <= 0)  // REFACTOR: Changed NULL to nullptr for modern C++
+    if (r == nullptr || e == nullptr || amount <= 0)
         return 1;
 
     genericChar str[256];
@@ -365,14 +365,14 @@ int TipDB::PayoutReceipt(Terminal *t, Employee *e, int amount, Report *r)
 int TipDB::ListReport(Terminal *t, Employee *e, Report *r)
 {
     FnTrace("TipDB::ListReport()");
-    if (r == nullptr || e == nullptr)  // REFACTOR: Changed NULL to nullptr for modern C++
+    if (r == nullptr || e == nullptr)
         return 1;
 
     Settings *s = t->GetSettings();
     int flag = e->IsSupervisor(s);
     int count = 0;
 
-    for (TipEntry *te = TipList(); te != nullptr; te = te->next)  // REFACTOR: Changed NULL to nullptr for modern C++
+    for (TipEntry *te = TipList(); te != nullptr; te = te->next)
     {
         if (te->user_id == e->id || flag)
         {
@@ -414,6 +414,6 @@ int TipDB::Update(System *sys)
         Calculate(s, &a->tip_db, sys->CheckList(), sys->DrawerList());
     }
     else
-        Calculate(s, nullptr, sys->CheckList(), sys->DrawerList());  // REFACTOR: Changed NULL to nullptr for modern C++
+        Calculate(s, nullptr, sys->CheckList(), sys->DrawerList());
     return 0;
 }

--- a/main/tips.hh
+++ b/main/tips.hh
@@ -18,7 +18,7 @@
  * Handeling of captured tips and tip payout
  */
 
-#pragma once  // REFACTOR: Replaced #ifndef _TIPS_HH guard with modern pragma once
+#pragma once
 
 #include "utility.hh"
 #include "list_utility.hh"
@@ -85,7 +85,7 @@ public:
     int Remove(TipEntry *te);
     int Purge();
     TipEntry *FindByUser(int id);
-    TipEntry *FindByRecord(int record, Employee *e = nullptr);  // REFACTOR: Changed NULL to nullptr for modern C++
+    TipEntry *FindByRecord(int record, Employee *e = nullptr);
     int CaptureTip(int user_id, int amount);
     int TransferTip(int user_id, int amount);
     int PayoutTip(int user_id, int amount);

--- a/remote_link.cc
+++ b/remote_link.cc
@@ -51,7 +51,7 @@ CharQueue::CharQueue(int max_size)
 
     buffer = new Uchar[buffer_size];
 
-    if (buffer == nullptr)  // REFACTOR: Changed NULL to nullptr for modern C++
+    if (buffer == nullptr)
         buffer_size = 0;
 
     Clear();

--- a/remote_link.hh
+++ b/remote_link.hh
@@ -1,4 +1,4 @@
-#pragma once  // REFACTOR: Replaced #ifndef VT_REMOTE_LINK_HH guard with modern pragma once
+#pragma once
 
 /*
  * Copyright ViewTouch, Inc., 1995, 1996, 1997, 1998  

--- a/scripts/vtcommands.pl
+++ b/scripts/vtcommands.pl
@@ -213,13 +213,17 @@ sub ShowHelp {
 # MakeDirs:
 # --------------------------------------------------------------------
 sub MakeDirs {
+    # REFACTOR FIX: Changed bin and dat directory permissions from 0755 to 0775
+    # to ensure both directories have identical permissions. This maintains
+    # consistency with existing /usr/viewtouch/bin directory which has 775 permissions.
+    # Combined with umask(0022) fix in main/manager.cc, this ensures proper directory access.
     unless ( -d $bindir ) {
-        if ( !mkdir( $bindir, 0755 ) ) {
+        if ( !mkdir( $bindir, 0775 ) ) {
             print STDERR "Failed to create $bindir:  $!\n";
         }
     }
     unless ( -d $datdir ) {
-        if ( !mkdir( $datdir, 0755 ) ) {
+        if ( !mkdir( $datdir, 0775 ) ) {
             print STDERR "Failed to create $datdir:  $!\n";
         }
     }

--- a/socket.cc
+++ b/socket.cc
@@ -203,8 +203,8 @@ const char* Sock_ntop(const struct sockaddr_in *sa, socklen_t addrlen)
     char portstr[STRLENGTH];
     static char str[STRLENGTH];
 
-    if (inet_ntop(AF_INET, &sa->sin_addr, str, sizeof(str)) == nullptr)  // REFACTOR: Changed NULL to nullptr for modern C++
-        return nullptr;  // REFACTOR: Changed NULL to nullptr for modern C++
+    if (inet_ntop(AF_INET, &sa->sin_addr, str, sizeof(str)) == nullptr)
+        return nullptr;
     if (ntohs(sa->sin_port) != 0)
     {
         snprintf(portstr, sizeof(portstr), ":%d", ntohs(sa->sin_port));

--- a/socket.hh
+++ b/socket.hh
@@ -1,4 +1,4 @@
-#pragma once  // REFACTOR: Replaced #ifndef VT_SOCKET_HH guard with modern pragma once
+#pragma once
 
 /*
  * Copyright ViewTouch, Inc., 1995, 1996, 1997, 1998  

--- a/term/layer.cc
+++ b/term/layer.cc
@@ -1329,7 +1329,7 @@ LayerList::LayerList()
 {
     FnTrace("LayerList::LayerList()");
 
-    dis = nullptr; // REFACTOR: NULL -> nullptr for modern C++
+    dis = nullptr;
     gfx = 0;
     win = 0;
     select_on = 0;
@@ -1337,7 +1337,7 @@ LayerList::LayerList()
     select_y1 = 0;
     select_x2 = 0;
     select_y2 = 0;
-    drag = nullptr; // REFACTOR: NULL -> nullptr for modern C++
+    drag = nullptr;
     drag_x = 0;
     drag_y = 0;
     mouse_x = 0;
@@ -1345,8 +1345,8 @@ LayerList::LayerList()
     screen_blanked = 0;
     active_frame_color = COLOR_DK_RED;
     inactive_frame_color = COLOR_DK_BLUE;
-    last_object = nullptr; // REFACTOR: NULL -> nullptr for modern C++
-    last_layer  = nullptr; // REFACTOR: NULL -> nullptr for modern C++
+    last_object = nullptr;
+    last_layer  = nullptr;
 }
 
 // Member Functions
@@ -1366,7 +1366,7 @@ int LayerList::Add(Layer *l, int update)
 {
     FnTrace("LayerList::Add()");
 
-    if (l == nullptr) // REFACTOR: NULL -> nullptr for modern C++
+    if (l == nullptr)
         return 1;
 
     list.AddToTail(l);
@@ -1386,7 +1386,7 @@ int LayerList::Remove(Layer *l, int update)
 {
     FnTrace("LayerList::Remove()");
 
-    if (l == nullptr) // REFACTOR: NULL -> nullptr for modern C++
+    if (l == nullptr)
         return 1;
 
     // check to see if layer was in active list
@@ -1414,7 +1414,7 @@ int LayerList::Remove(Layer *l, int update)
         UpdateArea(l->x, l->y, l->w, l->h);
         if (last_layer == l)
         {
-            last_object = nullptr; // REFACTOR: NULL -> nullptr for modern C++
+            last_object = nullptr;
             last_layer  = FindByPoint(mouse_x, mouse_y);
             if (last_layer)
                 last_layer->MouseEnter(this);
@@ -1436,13 +1436,13 @@ Layer *LayerList::FindByPoint(int x, int y)
 {
     FnTrace("LayerList::FindByPoint()");
 
-    for (Layer *l = list.Tail(); l != nullptr; l = l->fore) // REFACTOR: NULL -> nullptr for modern C++
+    for (Layer *l = list.Tail(); l != nullptr; l = l->fore)
     {
         if (l->IsPointIn(x, y))
             return l;
     }
 
-    return nullptr; // REFACTOR: NULL -> nullptr for modern C++
+    return nullptr;
 }
 
 Layer *LayerList::FindByID(int id)
@@ -1451,14 +1451,14 @@ Layer *LayerList::FindByID(int id)
 
     Layer *l;
 
-    for (l = list.Head(); l != nullptr; l = l->next) // REFACTOR: NULL -> nullptr for modern C++
+    for (l = list.Head(); l != nullptr; l = l->next)
         if (l->id == id)
             return l;
 
-    for (l = inactive.Head(); l != nullptr; l = l->next) // REFACTOR: NULL -> nullptr for modern C++
+    for (l = inactive.Head(); l != nullptr; l = l->next)
         if (l->id == id)
             return l;
-    return nullptr; // REFACTOR: NULL -> nullptr for modern C++
+    return nullptr;
 }
 
 int LayerList::SetScreenBlanker(int set)
@@ -1467,7 +1467,7 @@ int LayerList::SetScreenBlanker(int set)
 
     if (set == screen_blanked)
         return 1;
-    drag = nullptr; // REFACTOR: NULL -> nullptr for modern C++
+    drag = nullptr;
     screen_blanked = set;
     if (set)
         ShowCursor(CURSOR_BLANK);
@@ -1500,7 +1500,7 @@ int LayerList::UpdateAll(int select_all)
     }
     
     Layer *l = list.Head();
-    if (l == nullptr) // REFACTOR: NULL -> nullptr for modern C++
+    if (l == nullptr)
         return 0;
     
     if (select_all)
@@ -1514,7 +1514,7 @@ int LayerList::UpdateAll(int select_all)
     l->DrawArea(0, 0, l->w, l->h);
 
     Layer *next_layer = l->fore;
-    if (next_layer == nullptr) // REFACTOR: NULL -> nullptr for modern C++
+    if (next_layer == nullptr)
         return 0;
 
     int p0 = l->x;
@@ -1549,7 +1549,7 @@ int LayerList::UpdateArea(int ax, int ay, int aw, int ah)
         return 0;
     }
     
-    for (l = list.Head(); l != nullptr; l = l->next) // REFACTOR: NULL -> nullptr for modern C++
+    for (l = list.Head(); l != nullptr; l = l->next)
     {
         if (l->Overlap(ax, ay, aw, ah))
             l->update = 1;
@@ -1557,7 +1557,7 @@ int LayerList::UpdateArea(int ax, int ay, int aw, int ah)
 
     OptimalUpdateArea(ax, ay, aw, ah);
 
-    for (l = list.Head(); l != nullptr; l = l->next) // REFACTOR: NULL -> nullptr for modern C++
+    for (l = list.Head(); l != nullptr; l = l->next)
         l->update = 0;
     return 0;
 }
@@ -1578,7 +1578,7 @@ int LayerList::OptimalUpdateArea(int ax, int ay, int aw, int ah, Layer *end)
             break;
         l = l->fore;
     }
-    if (l == nullptr) // REFACTOR: NULL -> nullptr for modern C++
+    if (l == nullptr)
         return 0;
 
     RegionInfo r;
@@ -1590,7 +1590,7 @@ int LayerList::OptimalUpdateArea(int ax, int ay, int aw, int ah, Layer *end)
     }
 
     Layer *next_layer = l->fore;
-    if (next_layer == nullptr) // REFACTOR: NULL -> nullptr for modern C++
+    if (next_layer == nullptr)
         return 0;
 
     int p0 = l->x;

--- a/term/layer.hh
+++ b/term/layer.hh
@@ -18,7 +18,7 @@
  * Pixmap graphic buffer objects
  */
 
-#pragma once  // REFACTOR: Replaced #ifndef _LAYER_HH guard with modern pragma once
+#pragma once
 
 #include "term_view.hh"
 #include "list_utility.hh"
@@ -197,7 +197,7 @@ public:
     // redraws all layers (only layers with update flag if select_all = 0)
     int UpdateArea(int x, int y, int w, int h);
     // redraws all layers in region
-    int OptimalUpdateArea(int x, int y, int w, int h, Layer *end = nullptr);  // REFACTOR: Changed NULL to nullptr for modern C++
+    int OptimalUpdateArea(int x, int y, int w, int h, Layer *end = nullptr);
     // redraws all layers with update flag set in region
     int RubberBandOff();
     int RubberBandUpdate(int x, int y);

--- a/term/term_credit.hh
+++ b/term/term_credit.hh
@@ -19,7 +19,7 @@
  *   keeping them in vt_term ensures that only the local terminal will be locked.
  */
 
-#pragma once  // REFACTOR: Replaced #ifndef __TERM_CREDIT__ guard with modern pragma once
+#pragma once
 
 #include "utility.hh"
 

--- a/term/term_credit_cheq.hh
+++ b/term/term_credit_cheq.hh
@@ -19,7 +19,7 @@
  *   keeping them in vt_term ensures that only the local terminal will be locked.
  */
 
-#pragma once  // REFACTOR: Replaced #ifndef __TERM_CREDIT__ guard with modern pragma once
+#pragma once
 
 #include "utility.hh"
 

--- a/term/term_credit_mcve.hh
+++ b/term/term_credit_mcve.hh
@@ -19,7 +19,7 @@
  *   keeping them in vt_term ensures that only the local terminal will be locked.
  */
 
-#pragma once  // REFACTOR: Replaced #ifndef __TERM_CREDIT__ guard with modern pragma once
+#pragma once
 
 #include <mcve.h>
 #include "utility.hh"

--- a/term/term_dialog.hh
+++ b/term/term_dialog.hh
@@ -18,7 +18,7 @@
  * Implementation of edit mode dialogs
  */
 
-#pragma once  // REFACTOR: Replaced #ifndef _TERM_DIALOG_HH guard with modern pragma once
+#pragma once
 
 #include <Xm/Xm.h>
 #include "basic.hh"
@@ -67,7 +67,7 @@ public:
     // Member Functions
     int Clear();
     int Init(Widget parent, const genericChar* label, const genericChar* *option_name, int *option_value,
-             void *option_cb = nullptr, void *client_data = nullptr);  // REFACTOR: Changed NULL to nullptr for modern C++
+             void *option_cb = nullptr, void *client_data = nullptr);
     int Show(int flag);
     int Set(int val);
     int SetLabel(const char* label);

--- a/term/term_view.cc
+++ b/term/term_view.cc
@@ -42,9 +42,7 @@
 #include <dmalloc.h>
 #endif
 
-#include <filesystem>       // generic filesystem functions available since C++17
-
-namespace fs = std::filesystem;
+#include <sys/stat.h>       // for mkdir and stat functions
 
 // Add Xft for scalable font rendering
 #include <X11/Xft/Xft.h>
@@ -348,16 +346,16 @@ const char* FontNameClass::ToString()
  *------------------------------------------------------------------*/
 Xpm::Xpm()
 {
-    next = nullptr; // REFACTOR: NULL -> nullptr for modern C++
-    fore = nullptr; // REFACTOR: NULL -> nullptr for modern C++
+    next = nullptr;
+    fore = nullptr;
     width = 0;
     height = 0;
 }
 
 Xpm::Xpm(Pixmap pm)
 {
-    next = nullptr; // REFACTOR: NULL -> nullptr for modern C++
-    fore = nullptr; // REFACTOR: NULL -> nullptr for modern C++
+    next = nullptr;
+    fore = nullptr;
     width = 0;
     height = 0;
     pixmap = pm;
@@ -365,8 +363,8 @@ Xpm::Xpm(Pixmap pm)
 
 Xpm::Xpm(Pixmap pm, int w, int h)
 {
-    next = nullptr; // REFACTOR: NULL -> nullptr for modern C++
-    fore = nullptr; // REFACTOR: NULL -> nullptr for modern C++
+    next = nullptr;
+    fore = nullptr;
     width = w;
     height = h;
     pixmap = pm;
@@ -392,17 +390,17 @@ Xpm *Pixmaps::Get(int idx)
 {
     int curridx = 0;
     Xpm *currXpm = pixmaps.Head();
-    Xpm *retval = nullptr; // REFACTOR: NULL -> nullptr for modern C++
+    Xpm *retval = nullptr;
     
     if (pixmaps.Count() < 1)
         return retval;
 
-    while (currXpm != nullptr && curridx < count) // REFACTOR: NULL -> nullptr for modern C++
+    while (currXpm != nullptr && curridx < count)
     {
         if (curridx == idx)
         {
             retval = currXpm;
-            currXpm = nullptr; // REFACTOR: NULL -> nullptr for modern C++
+            currXpm = nullptr;
         }
         else
         {
@@ -416,7 +414,7 @@ Xpm *Pixmaps::Get(int idx)
 
 Xpm *Pixmaps::GetRandom()
 {
-    Xpm *retval = nullptr; // REFACTOR: NULL -> nullptr for modern C++
+    Xpm *retval = nullptr;
 
     if (pixmaps.Count() < 2)
         return retval;
@@ -437,17 +435,17 @@ Pixmaps PixmapList;
  ********************************************************************/
 
 LayerList Layers;
-Layer *MainLayer = nullptr; // REFACTOR: NULL -> nullptr for modern C++
+Layer *MainLayer = nullptr;
 
 int SocketNo = 0;
 
-Display *Dis = nullptr; // REFACTOR: NULL -> nullptr for modern C++
+Display *Dis = nullptr;
 GC       Gfx = 0;
 Window   MainWin;
 std::array<Pixmap, IMAGE_COUNT> Texture;
 Pixmap   ShadowPix;
 int      ScrDepth = 0;
-Visual  *ScrVis = nullptr; // REFACTOR: NULL -> nullptr for modern C++
+Visual  *ScrVis = nullptr;
 Colormap ScrCol = 0;
 int      WinWidth  = 0;
 int      WinHeight = 0;
@@ -482,9 +480,9 @@ Str StoreName;
 Str Message;
 
 static XtAppContext App;
-static Widget       MainShell = nullptr; // REFACTOR: NULL -> nullptr for modern C++
+static Widget       MainShell = nullptr;
 static int          ScrNo     = 0;
-static Screen      *ScrPtr    = nullptr; // REFACTOR: NULL -> nullptr for modern C++
+static Screen      *ScrPtr    = nullptr;
 static int          ScrHeight = 0;
 static int          ScrWidth  = 0;
 static Window       RootWin;
@@ -494,7 +492,7 @@ static Ulong        Palette[256];
 static int          ScreenBlankTime = 60;
 static int          UpdateTimerID = 0;
 static int          TouchInputID  = 0;
-static TouchScreen *TScreen = nullptr; // REFACTOR: NULL -> nullptr for modern C++
+static TouchScreen *TScreen = nullptr;
 static int          ResetTime = 20;
 static TimeInfo     TimeOut, LastInput;
 static int          CalibrateStage = 0;
@@ -504,12 +502,12 @@ static Cursor       CursorBlank = 0;
 static Cursor       CursorWait = 0;
 
 #ifndef NO_MOTIF
-static PageDialog      *PDialog = nullptr; // REFACTOR: NULL -> nullptr for modern C++
-static ZoneDialog      *ZDialog = nullptr; // REFACTOR: NULL -> nullptr for modern C++
-static MultiZoneDialog *MDialog = nullptr; // REFACTOR: NULL -> nullptr for modern C++
-static TranslateDialog *TDialog = nullptr; // REFACTOR: NULL -> nullptr for modern C++
-static ListDialog      *LDialog = nullptr; // REFACTOR: NULL -> nullptr for modern C++
-static DefaultDialog   *DDialog = nullptr; // REFACTOR: NULL -> nullptr for modern C++
+static PageDialog      *PDialog = nullptr;
+static ZoneDialog      *ZDialog = nullptr;
+static MultiZoneDialog *MDialog = nullptr;
+static TranslateDialog *TDialog = nullptr;
+static ListDialog      *LDialog = nullptr;
+static DefaultDialog   *DDialog = nullptr;
 #endif
 
 // So that translations aren't done every time a dialog is opened, we'll
@@ -533,7 +531,7 @@ struct timeval last_mouse_time;
 int last_x_pos = 0;
 int last_y_pos = 0;
 
-CCard *creditcard = nullptr; // REFACTOR: NULL -> nullptr for modern C++
+CCard *creditcard = nullptr;
 int ConnectionTimeOut = 30;
 
 int allow_iconify = 1;
@@ -572,7 +570,7 @@ genericChar* RStr(genericChar* s)
     FnTrace("RStr()");
 
     static genericChar buffer[1024] = "";
-    if (s == nullptr) // REFACTOR: NULL -> nullptr for modern C++
+    if (s == nullptr)
         s = buffer;
     BufferIn.GetString(s);
     return s;
@@ -599,8 +597,8 @@ Translation::Translation()
 {
     FnTrace("Translation::Translation()");
 
-    next = nullptr; // REFACTOR: NULL -> nullptr for modern C++
-    fore = nullptr; // REFACTOR: NULL -> nullptr for modern C++
+    next = nullptr;
+    fore = nullptr;
     key[0] = '\0';
     value[0] = '\0';
 }
@@ -609,8 +607,8 @@ Translation::Translation(const char* new_key, const char* new_value)
 {
     FnTrace("Translation::Translation()");
 
-    next = nullptr; // REFACTOR: NULL -> nullptr for modern C++
-    fore = nullptr; // REFACTOR: NULL -> nullptr for modern C++
+    next = nullptr;
+    fore = nullptr;
     key[0] = '\0';
     strncpy(key, new_key, STRLONG);
     value[0] = '\0';
@@ -672,7 +670,7 @@ const char* Translations::GetTranslation(const char* key)
     FnTrace("Translations::GetTranslation()");
 
     Translation *trans = trans_list.Head();
-    while (trans != nullptr) // REFACTOR: NULL -> nullptr for modern C++
+    while (trans != nullptr)
     {
         if (trans->Match(key))
         {
@@ -693,7 +691,7 @@ void Translations::PrintTranslations()
     char key[STRLONG];
     char value[STRLONG];
 
-    while (trans != nullptr) // REFACTOR: NULL -> nullptr for modern C++
+    while (trans != nullptr)
     {
         trans->GetKey(key, STRLONG);
         trans->GetValue(value, STRLONG);
@@ -860,7 +858,7 @@ void TouchScreenCB(XtPointer client_data, int *fid, XtInputId *id)
     FnTrace("TouchScreenCB()");
 
     TouchScreen *ts = TScreen;
-    if (ts == nullptr && silent_mode > 0) // REFACTOR: NULL -> nullptr for modern C++
+    if (ts == nullptr && silent_mode > 0)
         return;
 
     int tx = -1;
@@ -944,7 +942,7 @@ void KeyPressCB(Widget widget, XtPointer client_data,
     KeySym key = 0;
     genericChar buffer[32];
 
-    int len = XLookupString(e, buffer, 31, &key, nullptr); // REFACTOR: NULL -> nullptr for modern C++
+    int len = XLookupString(e, buffer, 31, &key, nullptr);
     if (len < 0)
         len = 0;
     buffer[len] = '\0';
@@ -1679,9 +1677,9 @@ void SocketInputCB(XtPointer client_data, int *fid, XtInputId *id)
             new_zone_translations = 1;
             break;
         case TERM_CC_AUTH:
-            if (creditcard == nullptr) // REFACTOR: NULL -> nullptr for modern C++
+            if (creditcard == nullptr)
                 creditcard = new CCard;
-            if (creditcard != nullptr) // REFACTOR: NULL -> nullptr for modern C++
+            if (creditcard != nullptr)
             {
                 creditcard->Read();
                 creditcard->Sale();
@@ -1692,9 +1690,9 @@ void SocketInputCB(XtPointer client_data, int *fid, XtInputId *id)
             }
             break;
         case TERM_CC_PREAUTH:
-            if (creditcard == nullptr) // REFACTOR: NULL -> nullptr for modern C++
+            if (creditcard == nullptr)
                 creditcard = new CCard;
-            if (creditcard != nullptr) // REFACTOR: NULL -> nullptr for modern C++
+            if (creditcard != nullptr)
             {
                 creditcard->Read();
                 creditcard->PreAuth();
@@ -1705,9 +1703,9 @@ void SocketInputCB(XtPointer client_data, int *fid, XtInputId *id)
             }
             break;
         case TERM_CC_FINALAUTH:
-            if (creditcard == nullptr) // REFACTOR: NULL -> nullptr for modern C++
+            if (creditcard == nullptr)
                 creditcard = new CCard;
-            if (creditcard != nullptr) // REFACTOR: NULL -> nullptr for modern C++
+            if (creditcard != nullptr)
             {
                 creditcard->Read();
                 creditcard->FinishAuth();
@@ -1718,9 +1716,9 @@ void SocketInputCB(XtPointer client_data, int *fid, XtInputId *id)
             }
             break;
         case TERM_CC_VOID:
-            if (creditcard == nullptr) // REFACTOR: NULL -> nullptr for modern C++
+            if (creditcard == nullptr)
                 creditcard = new CCard;
-            if (creditcard != nullptr) // REFACTOR: NULL -> nullptr for modern C++
+            if (creditcard != nullptr)
             {
                 creditcard->Read();
                 creditcard->Void();
@@ -1731,9 +1729,9 @@ void SocketInputCB(XtPointer client_data, int *fid, XtInputId *id)
             }
             break;
         case TERM_CC_VOID_CANCEL:
-            if (creditcard == nullptr) // REFACTOR: NULL -> nullptr for modern C++
+            if (creditcard == nullptr)
                 creditcard = new CCard;
-            if (creditcard != nullptr) // REFACTOR: NULL -> nullptr for modern C++
+            if (creditcard != nullptr)
             {
                 creditcard->Read();
                 creditcard->VoidCancel();
@@ -1744,9 +1742,9 @@ void SocketInputCB(XtPointer client_data, int *fid, XtInputId *id)
             }
             break;
         case TERM_CC_REFUND:
-            if (creditcard == nullptr) // REFACTOR: NULL -> nullptr for modern C++
+            if (creditcard == nullptr)
                 creditcard = new CCard;
-            if (creditcard != nullptr) // REFACTOR: NULL -> nullptr for modern C++
+            if (creditcard != nullptr)
             {
                 creditcard->Read();
                 creditcard->Refund();
@@ -1757,9 +1755,9 @@ void SocketInputCB(XtPointer client_data, int *fid, XtInputId *id)
             }
             break;
         case TERM_CC_REFUND_CANCEL:
-            if (creditcard == nullptr) // REFACTOR: NULL -> nullptr for modern C++
+            if (creditcard == nullptr)
                 creditcard = new CCard;
-            if (creditcard != nullptr) // REFACTOR: NULL -> nullptr for modern C++
+            if (creditcard != nullptr)
             {
                 creditcard->Read();
                 creditcard->RefundCancel();
@@ -1771,54 +1769,54 @@ void SocketInputCB(XtPointer client_data, int *fid, XtInputId *id)
             break;
         case TERM_CC_SETTLE:
             // BatchSettle() should also write the response to vt_main
-            if (creditcard == nullptr) // REFACTOR: NULL -> nullptr for modern C++
+            if (creditcard == nullptr)
                 creditcard = new CCard;
-            if (creditcard != nullptr) // REFACTOR: NULL -> nullptr for modern C++
+            if (creditcard != nullptr)
             {
                 creditcard->BatchSettle();
                 creditcard->Clear();
             }
             break;
         case TERM_CC_INIT:
-            if (creditcard == nullptr) // REFACTOR: NULL -> nullptr for modern C++
+            if (creditcard == nullptr)
                 creditcard = new CCard;
-            if (creditcard != nullptr) // REFACTOR: NULL -> nullptr for modern C++
+            if (creditcard != nullptr)
             {
                 creditcard->CCInit();
                 creditcard->Clear();
             }
             break;
         case TERM_CC_TOTALS:
-            if (creditcard == nullptr) // REFACTOR: NULL -> nullptr for modern C++
+            if (creditcard == nullptr)
                 creditcard = new CCard;
-            if (creditcard != nullptr) // REFACTOR: NULL -> nullptr for modern C++
+            if (creditcard != nullptr)
             {
                 creditcard->Totals();
                 creditcard->Clear();
             }
             break;
         case TERM_CC_DETAILS:
-            if (creditcard == nullptr) // REFACTOR: NULL -> nullptr for modern C++
+            if (creditcard == nullptr)
                 creditcard = new CCard;
-            if (creditcard != nullptr) // REFACTOR: NULL -> nullptr for modern C++
+            if (creditcard != nullptr)
             {
                 creditcard->Details();
                 creditcard->Clear();
             }
             break;
         case TERM_CC_CLEARSAF:
-            if (creditcard == nullptr) // REFACTOR: NULL -> nullptr for modern C++
+            if (creditcard == nullptr)
                 creditcard = new CCard;
-            if (creditcard != nullptr) // REFACTOR: NULL -> nullptr for modern C++
+            if (creditcard != nullptr)
             {
                 creditcard->ClearSAF();
                 creditcard->Clear();
             }
             break;
         case TERM_CC_SAFDETAILS:
-            if (creditcard == nullptr) // REFACTOR: NULL -> nullptr for modern C++
+            if (creditcard == nullptr)
                 creditcard = new CCard;
-            if (creditcard != nullptr) // REFACTOR: NULL -> nullptr for modern C++
+            if (creditcard != nullptr)
             {
                 creditcard->SAFDetails();
                 creditcard->Clear();
@@ -1835,8 +1833,8 @@ void SocketInputCB(XtPointer client_data, int *fid, XtInputId *id)
  * General Functions
  ********************************************************************/
 
-Layer       *TargetLayer = nullptr; // REFACTOR: NULL -> nullptr for modern C++
-LayerObject *TargetObject = nullptr; // REFACTOR: NULL -> nullptr for modern C++
+Layer       *TargetLayer = nullptr;
+LayerObject *TargetObject = nullptr;
 
 int OpenLayer(int id, int x, int y, int w, int h, int win_frame, const genericChar* title)
 {
@@ -1850,7 +1848,7 @@ int OpenLayer(int id, int x, int y, int w, int h, int win_frame, const genericCh
 
     KillLayer(id);
     Layer *l = new Layer(Dis, Gfx, MainWin, w, h);
-    if (l == nullptr) // REFACTOR: NULL -> nullptr for modern C++
+    if (l == nullptr)
         return 1;
 
     if (l->pix == 0)
@@ -1879,7 +1877,7 @@ int ShowLayer(int id)
     FnTrace("ShowLayer()");
 
     Layer *l = Layers.FindByID(id);
-    if (l == nullptr) // REFACTOR: NULL -> nullptr for modern C++
+    if (l == nullptr)
         return 1;
 
     l->buttons.Render(l);
@@ -1912,7 +1910,7 @@ int SetTargetLayer(int id)
     FnTrace("SetTargetLayer()");
 
     Layer *l = Layers.FindByID(id);
-    if (l == nullptr) // REFACTOR: NULL -> nullptr for modern C++
+    if (l == nullptr)
         return 1;
 
     TargetLayer = l;
@@ -1925,7 +1923,7 @@ int NewPushButton(int id, int x, int y, int w, int h, const genericChar* text,
     FnTrace("NewPushButton()");
 
     Layer *l = TargetLayer;
-    if (l == nullptr) // REFACTOR: NULL -> nullptr for modern C++
+    if (l == nullptr)
         return 1;
     LO_PushButton *b = new LO_PushButton(text, c1, c2);
     b->SetRegion(x + l->offset_x, y + l->offset_y, w, h);
@@ -2205,12 +2203,13 @@ int ReadScreenSaverPix()
     Xpm *newpm;
     genericChar fullpath[STRLONG];
     int len;
-    if (!fs::is_directory(SCREENSAVER_DIR))
+    struct stat st;
+    if (stat(SCREENSAVER_DIR, &st) != 0 || !S_ISDIR(st.st_mode))
     {
         std::cerr << "Screen saver directory does not exist: '"
             << SCREENSAVER_DIR << "' creating it" << std::endl;
-        fs::create_directory(SCREENSAVER_DIR);
-        fs::permissions(SCREENSAVER_DIR, fs::perms::all); // be sure read/write/execute flags are set
+        mkdir(SCREENSAVER_DIR, 0755);
+        chmod(SCREENSAVER_DIR, 0755); // set read/write/execute permissions
     }
     dp = opendir(SCREENSAVER_DIR);
     if (dp == nullptr)
@@ -2890,26 +2889,55 @@ Pixmap GetTexture(int texture)
         return Texture[0]; // default texture
 }
 
-// Function to get scalable font names for Xft
+// Function to get scalable font names for Xft - consistent with manager.cc
 const char* GetScalableFontName(int font_id)
 {
     switch (font_id)
     {
-    case FONT_TIMES_20:   return "Times:size=20:style=regular";
-    case FONT_TIMES_24:   return "Times:size=24:style=regular";
-    case FONT_TIMES_34:   return "Times:size=34:style=regular";
-    case FONT_TIMES_20B:  return "Times:size=20:style=bold";
-    case FONT_TIMES_24B:  return "Times:size=24:style=bold";
-    case FONT_TIMES_34B:  return "Times:size=34:style=bold";
-    case FONT_TIMES_14:   return "Times:size=14:style=regular";
-    case FONT_TIMES_14B:  return "Times:size=14:style=bold";
-    case FONT_TIMES_18:   return "Times:size=18:style=regular";
-    case FONT_TIMES_18B:  return "Times:size=18:style=bold";
-    case FONT_COURIER_18: return "Courier:size=18:style=regular";
-    case FONT_COURIER_18B: return "Courier:size=18:style=bold";
-    case FONT_COURIER_20: return "Courier:size=20:style=regular";
-    case FONT_COURIER_20B: return "Courier:size=20:style=bold";
-    default:              return "Times:size=24:style=regular";
+    // Legacy Times fonts (kept for compatibility)
+    case FONT_TIMES_14:  return "Times New Roman-14:style=Regular";
+    case FONT_TIMES_18:  return "Times New Roman-18:style=Regular";
+    case FONT_TIMES_20:  return "Times New Roman-20:style=Regular";
+    case FONT_TIMES_24:  return "Times New Roman-24:style=Regular";
+    case FONT_TIMES_34:  return "Times New Roman-34:style=Regular";
+    case FONT_TIMES_14B: return "Times New Roman-14:style=Bold";
+    case FONT_TIMES_18B: return "Times New Roman-18:style=Bold";
+    case FONT_TIMES_20B: return "Times New Roman-20:style=Bold";
+    case FONT_TIMES_24B: return "Times New Roman-24:style=Bold";
+    case FONT_TIMES_34B: return "Times New Roman-34:style=Bold";
+    case FONT_COURIER_18: return "Courier New-18:style=Regular";
+    case FONT_COURIER_18B: return "Courier New-18:style=Bold";
+    case FONT_COURIER_20: return "Courier New-20:style=Regular";
+    case FONT_COURIER_20B: return "Courier New-20:style=Bold";
+    
+    // Modern POS Fonts - DejaVu Sans (Superior readability for POS)
+    case FONT_DEJAVU_14:  return "DejaVu Sans-14:style=Book";
+    case FONT_DEJAVU_16:  return "DejaVu Sans-16:style=Book";
+    case FONT_DEJAVU_18:  return "DejaVu Sans-18:style=Book";
+    case FONT_DEJAVU_20:  return "DejaVu Sans-20:style=Book";
+    case FONT_DEJAVU_24:  return "DejaVu Sans-24:style=Book";
+    case FONT_DEJAVU_28:  return "DejaVu Sans-28:style=Book";
+    case FONT_DEJAVU_14B: return "DejaVu Sans-14:style=Bold";
+    case FONT_DEJAVU_16B: return "DejaVu Sans-16:style=Bold";
+    case FONT_DEJAVU_18B: return "DejaVu Sans-18:style=Bold";
+    case FONT_DEJAVU_20B: return "DejaVu Sans-20:style=Bold";
+    case FONT_DEJAVU_24B: return "DejaVu Sans-24:style=Bold";
+    case FONT_DEJAVU_28B: return "DejaVu Sans-28:style=Bold";
+    
+    // Monospace fonts - Perfect for prices, numbers, and financial data
+    case FONT_MONO_14:    return "DejaVu Sans Mono-14:style=Book";
+    case FONT_MONO_16:    return "DejaVu Sans Mono-16:style=Book";
+    case FONT_MONO_18:    return "DejaVu Sans Mono-18:style=Book";
+    case FONT_MONO_20:    return "DejaVu Sans Mono-20:style=Book";
+    case FONT_MONO_24:    return "DejaVu Sans Mono-24:style=Book";
+    case FONT_MONO_14B:   return "DejaVu Sans Mono-14:style=Bold";
+    case FONT_MONO_16B:   return "DejaVu Sans Mono-16:style=Bold";
+    case FONT_MONO_18B:   return "DejaVu Sans Mono-18:style=Bold";
+    case FONT_MONO_20B:   return "DejaVu Sans Mono-20:style=Bold";
+    case FONT_MONO_24B:   return "DejaVu Sans Mono-24:style=Bold";
+    
+    // Default to modern DejaVu Sans instead of Times New Roman
+    default:              return "DejaVu Sans-18:style=Book";
     }
 }
 

--- a/term/term_view.hh
+++ b/term/term_view.hh
@@ -6,7 +6,7 @@
  * Terminal Display module
  */
 
-#pragma once  // REFACTOR: Replaced #ifndef _TERM_VIEW_HH guard with modern pragma once
+#pragma once
 
 #include "list_utility.hh"
 #include "utility.hh"
@@ -198,6 +198,33 @@ enum page_sizes {
 #define FONT_COURIER_18B 15
 #define FONT_COURIER_20  16
 #define FONT_COURIER_20B 17
+
+// Modern POS Fonts - DejaVu Sans (Superior for POS interfaces)
+#define FONT_DEJAVU_14    18
+#define FONT_DEJAVU_16    19
+#define FONT_DEJAVU_18    20
+#define FONT_DEJAVU_20    21
+#define FONT_DEJAVU_24    22
+#define FONT_DEJAVU_28    23
+#define FONT_DEJAVU_14B   24
+#define FONT_DEJAVU_16B   25
+#define FONT_DEJAVU_18B   26
+#define FONT_DEJAVU_20B   27
+#define FONT_DEJAVU_24B   28
+#define FONT_DEJAVU_28B   29
+
+// Monospace Fonts - Perfect for prices and numbers
+#define FONT_MONO_14      30
+#define FONT_MONO_16      31
+#define FONT_MONO_18      32
+#define FONT_MONO_20      33
+#define FONT_MONO_24      34
+#define FONT_MONO_14B     35
+#define FONT_MONO_16B     36
+#define FONT_MONO_18B     37
+#define FONT_MONO_20B     38
+#define FONT_MONO_24B     39
+
 #define FONT_UNDERLINE  128
 
 // Zone Frame Appearence

--- a/term/touch_screen.hh
+++ b/term/touch_screen.hh
@@ -18,7 +18,7 @@
  * functions for using the touch-screen services
  */
 
-#pragma once  // REFACTOR: Replaced #ifndef _TOUCH_SCREEN_HH guard with modern pragma once
+#pragma once
 
 #include <string>
 #include "utility.hh"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,8 @@
+# Tests CMakeLists.txt
+
+# Add existing test directories
+add_subdirectory(conf_file)
+add_subdirectory(data_file)
+add_subdirectory(image_data)
+add_subdirectory(main)
+add_subdirectory(time_info) 

--- a/tests/main/manager_stub.cc
+++ b/tests/main/manager_stub.cc
@@ -401,7 +401,7 @@ int StartSystem(int my_use_net)
     }
 
     genericChar str[256];
-    EnsureFileExists(sys->data_path.Value());
+    EnsureDirExists(sys->data_path.Value());
     if (DoesFileExist(sys->data_path.Value()) == 0)
     {
         sprintf(str, "Can't find path '%s'", sys->data_path.Value());

--- a/time_info.hh
+++ b/time_info.hh
@@ -1,4 +1,4 @@
-#pragma once  // REFACTOR: Replaced #ifndef VT_TIME_INFO_HH guard with modern pragma once
+#pragma once
 
 /*
  * Copyright ViewTouch, Inc., 1995, 1996, 1997, 1998  

--- a/utility.cc
+++ b/utility.cc
@@ -38,14 +38,14 @@
 void Str::ChangeAtoB(const char a, const char b)
 {
     FnTrace("Str::ChangeAtoB()");
-    std::replace(data.begin(), data.end(), a, b);  // REFACTOR: Using std::string's internal data member
+    std::replace(data.begin(), data.end(), a, b);
 }
 
 int Str::IntValue() const
 {
     FnTrace("Str::IntValue()");
-    if (!data.empty())                             // REFACTOR: Using std::string's empty() method
-        return std::stoi(data);                    // REFACTOR: Using modern std::stoi instead of atoi
+    if (!data.empty())
+        return std::stoi(data);
     else
         return 0;
 }
@@ -53,8 +53,8 @@ int Str::IntValue() const
 Flt Str::FltValue() const
 {
     FnTrace("Str::FltValue()");
-    if (!data.empty())                             // REFACTOR: Using std::string's empty() method
-        return std::stod(data);                    // REFACTOR: Using modern std::stod instead of atof
+    if (!data.empty())
+        return std::stod(data);
     else
         return 0.0;
 }
@@ -63,38 +63,38 @@ const char* Str::ValueSet(const char* set)
 {
     FnTrace("Str::ValueSet()");
     if (set != nullptr)                            // REFACTOR: Changed NULL to nullptr
-        data = set;                                // REFACTOR: Direct assignment to std::string data
-    return data.c_str();                           // REFACTOR: Return c_str() of std::string data
+        data = set;
+    return data.c_str();
 }
 
 int Str::operator > (const Str &s) const
 {
     FnTrace("Str::operator >()");
-    return this->data > s.data;                    // REFACTOR: Direct std::string comparison
+    return this->data > s.data;
 }
 
 int Str::operator < (const Str &s) const
 {
     FnTrace("Str::operator <()");
-    return this->data < s.data;                    // REFACTOR: Direct std::string comparison
+    return this->data < s.data;
 }
 
 int Str::operator == (const Str &s) const
 {
     FnTrace("Str::opterator ==()");
-    return this->data == s.data;                   // REFACTOR: Direct std::string comparison
+    return this->data == s.data;
 }
 
 bool Str::operator ==(const std::string &s) const
 {
     FnTrace("Str::opterator ==()");
-    return this->data == s;                        // REFACTOR: Direct std::string comparison
+    return this->data == s;
 }
 
 int Str::operator != (const Str &s) const
 {
     FnTrace("Str::operator !=()");
-    return this->data != s.data;                   // REFACTOR: Direct std::string comparison
+    return this->data != s.data;
 }
 
 /**** RegionInfo Class ****/
@@ -179,10 +179,10 @@ int RegionInfo::Intersect(int rx, int ry, int rw, int rh)
     {
         // intersection
         retval = 0;
-        int left   = Max((int)x, rx);                // REFACTOR: Cast to int for template type matching
-        int top    = Max((int)y, ry);                // REFACTOR: Cast to int for template type matching
-        int right  = Min((int)(x + w - 1), rx + rw - 1);     // REFACTOR: Cast to int for template type matching
-        int bottom = Min((int)(y + h - 1), ry + rh - 1);     // REFACTOR: Cast to int for template type matching
+        int left   = Max((int)x, rx);
+        int top    = Max((int)y, ry);
+        int right  = Min((int)(x + w - 1), rx + rw - 1);
+        int bottom = Min((int)(y + h - 1), ry + rh - 1);
         x = left;
         y = top;
         w = right - left + 1;
@@ -562,7 +562,7 @@ int DoesFileExist(const genericChar* filename)
 int EnsureFileExists(const genericChar* filename)
 {
     FnTrace("EnsureFileExists()");
-    if (filename == nullptr)                       // REFACTOR: Changed NULL to nullptr
+    if (filename == nullptr)
         return 1;
 
     if (DoesFileExist(filename))
@@ -574,6 +574,28 @@ int EnsureFileExists(const genericChar* filename)
         close(fd);
         return 0;
     }
+    return 1;
+}
+
+int EnsureDirExists(const genericChar* dirname)
+{
+    FnTrace("EnsureDirExists()");
+    if (dirname == nullptr)
+        return 1;
+
+    struct stat st;
+    if (stat(dirname, &st) == 0)
+    {
+        if (S_ISDIR(st.st_mode))
+            return 0; // Directory already exists
+        else
+            return 1; // Path exists but is not a directory
+    }
+
+    // Create directory with proper permissions
+    if (mkdir(dirname, 0755) == 0)
+        return 0;
+    
     return 1;
 }
 
@@ -676,14 +698,14 @@ int UnlockDevice(int id)
 // REFACTOR: Added setproctitle implementations to fix linker error
 // These functions allow setting the process title visible in ps/top commands
 
-static char **vt_argv = nullptr;           // REFACTOR: Store original argv pointer
+static char **vt_argv = nullptr;
 static size_t vt_argv_space = 0;           // REFACTOR: Available space for process title
 
 void vt_init_setproctitle(int argc, char* argv[])
 {
     FnTrace("vt_init_setproctitle()");
     
-    // REFACTOR: Store argv pointer and calculate available space for process title
+
     vt_argv = argv;
     
     if (argc > 0 && argv != nullptr && argv[0] != nullptr)  // REFACTOR: Safety checks with nullptr
@@ -715,8 +737,8 @@ int vt_setproctitle(const char* title)
         return -1;
         
     // Clear the argv space and set new title
-    memset(vt_argv[0], 0, vt_argv_space);                    // REFACTOR: Clear existing argv space
-    strncpy(vt_argv[0], title, vt_argv_space - 1);           // REFACTOR: Copy new title safely
+    memset(vt_argv[0], 0, vt_argv_space);
+    strncpy(vt_argv[0], title, vt_argv_space - 1);
     vt_argv[0][vt_argv_space - 1] = '\0';                    // REFACTOR: Ensure null termination
     
     return 0;

--- a/utility.hh
+++ b/utility.hh
@@ -1,5 +1,3 @@
-#pragma once  // REFACTOR: Replaced #ifndef VT_UTILITY_HH guard with modern pragma once
-
 /*
  * Copyright ViewTouch, Inc., 1995, 1996, 1997, 1998  
   
@@ -19,6 +17,8 @@
  * utility.hh - revision 106 (10/20/98)
  * General functions and data types than have no other place to go
  */
+
+#pragma once
 
 #include "basic.hh"
 #include "fntrace.hh"
@@ -66,68 +66,67 @@ enum SignalResult
     SIGNAL_TERMINATE   // signal received - terminate me
 };
 
-// REFACTOR: Completely modernized Str class with C++17 features and RAII
+
 // Dynamic string storage class
 class Str
 {
-    std::string data;  // REFACTOR: Changed from public to private member for encapsulation
+    std::string data;
 
 public:
-    Str*   next = nullptr;  // REFACTOR: Added default nullptr initialization
-    Str*   fore = nullptr;  // REFACTOR: Added default nullptr initialization
+    Str*   next = nullptr;
+    Str*   fore = nullptr;
 
-    // REFACTOR: Added modern C++17 constructors with proper initialization
+
     // Constructors
-    Str() = default;                                               // REFACTOR: Defaulted default constructor
+    Str() = default;
     explicit Str(const std::string& str) : data(str) {}           // REFACTOR: Added explicit constructor from std::string
     explicit Str(const char* str) : data(str ? str : "") {}       // REFACTOR: Added explicit constructor from C-string with null check
     
-    // REFACTOR: Added modern copy semantics for proper object management
+
     // Copy operations
-    Str(const Str& other) = default;                              // REFACTOR: Defaulted copy constructor
-    Str& operator=(const Str& other) = default;                   // REFACTOR: Defaulted copy assignment
+    Str(const Str& other) = default;
+    Str& operator=(const Str& other) = default;
     
-    // REFACTOR: Added modern move semantics for performance optimization
+
     // Move operations  
     Str(Str&& other) noexcept = default;                          // REFACTOR: Added move constructor
-    Str& operator=(Str&& other) noexcept = default;               // REFACTOR: Added move assignment
+    Str& operator=(Str&& other) noexcept = default;
     
-    // REFACTOR: Defaulted destructor for RAII compliance
+
     // Destructor
-    ~Str() = default;                                              // REFACTOR: Defaulted destructor
+    ~Str() = default;
 
     // REFACTOR: Converted methods to inline implementations for performance
     // Methods
-    int   Clear() { data.clear(); return 0; }                                     // REFACTOR: Made inline, was external implementation
-    bool  Set(const char *str) { data = str ? str : ""; return true; }           // REFACTOR: Made inline with null check
-    bool  Set(const std::string &str) { data = str; return true; }               // REFACTOR: Made inline
-    bool  Set(const int val) { data = std::to_string(val); return true; }        // REFACTOR: Made inline
-    bool  Set(const Flt val) { data = std::to_string(val); return true; }        // REFACTOR: Made inline
-    bool  Set(const Str &s) { data = s.data; return true; }                      // REFACTOR: Added Str-to-Str assignment
+    int   Clear() { data.clear(); return 0; }
+    bool  Set(const char *str) { data = str ? str : ""; return true; }
+    bool  Set(const std::string &str) { data = str; return true; }
+    bool  Set(const int val) { data = std::to_string(val); return true; }
+    bool  Set(const Flt val) { data = std::to_string(val); return true; }
+    bool  Set(const Str &s) { data = s.data; return true; }
     bool  Set(const Str *s) { return Set(s->Value()); }                          // REFACTOR: Added pointer variant
-    void  ChangeAtoB(const char a, const char b);                                // REFACTOR: Kept as external implementation
-    int   IntValue() const;                                                       // REFACTOR: Kept as external implementation
-    Flt   FltValue() const;                                                       // REFACTOR: Kept as external implementation
-    const char *Value() const { return data.c_str(); }                           // REFACTOR: Made inline accessor
-    const char *c_str() const { return data.c_str(); }                           // REFACTOR: Made inline accessor
-    std::string str() const { return data; }                                     // REFACTOR: Made inline accessor
-    const char* ValueSet(const char* set = nullptr);                             // REFACTOR: Kept as external implementation
+    void  ChangeAtoB(const char a, const char b);
+    int   IntValue() const;
+    Flt   FltValue() const;
+    const char *Value() const { return data.c_str(); }
+    const char *c_str() const { return data.c_str(); }
+    std::string str() const { return data; }
+    const char* ValueSet(const char* set = nullptr);
 
-    bool   empty() const { return data.empty(); }                                // REFACTOR: Made inline accessor
-    size_t size() const { return data.size(); }                                  // REFACTOR: Made inline accessor
+    bool   empty() const { return data.empty(); }
+    size_t size() const { return data.size(); }
 
-    // REFACTOR: Added assignment operators for backward compatibility
     // Assignment operators for compatibility
-    Str & operator =  (const char* s) { Set(s); return *this; }                  // REFACTOR: Added C-string assignment
-    Str & operator =  (const std::string &s) { Set(s); return *this; }           // REFACTOR: Added std::string assignment
-    Str & operator =  (const int s) { Set(s); return *this; }                    // REFACTOR: Added integer assignment
-    Str & operator =  (const Flt s) { Set(s); return *this; }                    // REFACTOR: Added float assignment
+    Str & operator =  (const char* s) { Set(s); return *this; }
+    Str & operator =  (const std::string &s) { Set(s); return *this; }
+    Str & operator =  (const int s) { Set(s); return *this; }
+    Str & operator =  (const Flt s) { Set(s); return *this; }
 
-    int   operator >  (const Str  &s) const;                                     // REFACTOR: Kept as external implementation
-    int   operator <  (const Str  &s) const;                                     // REFACTOR: Kept as external implementation
-    int   operator == (const Str  &s) const;                                     // REFACTOR: Kept as external implementation
-    bool operator == (const std::string &s) const;                               // REFACTOR: Kept as external implementation
-    int   operator != (const Str  &s) const;                                     // REFACTOR: Kept as external implementation
+    int   operator >  (const Str  &s) const;
+    int   operator <  (const Str  &s) const;
+    int   operator == (const Str  &s) const;
+    bool operator == (const std::string &s) const;
+    int   operator != (const Str  &s) const;
 };
 
 // Rectangular Region class
@@ -266,6 +265,7 @@ int DoesFileExist(const genericChar* filename);
 // Returns 1 if file exists otherwise 0
 
 int EnsureFileExists(const genericChar* filename);
+int EnsureDirExists(const genericChar* dirname);
 
 int DeleteFile(const genericChar* filename);
 // Deletes file from disk

--- a/version/vt_version_info.hh
+++ b/version/vt_version_info.hh
@@ -1,4 +1,4 @@
-#pragma once  // REFACTOR: Replaced #ifndef VT_VERSION_INFO_HPP guard with modern pragma once
+#pragma once
 
 #include <string>
 

--- a/vt_ccq_pipe.hh
+++ b/vt_ccq_pipe.hh
@@ -21,4 +21,4 @@
  *  socket.  And vice versa.
  */
 
-#pragma once  // REFACTOR: Replaced #ifndef VT_CCQ_PIPE_H guard with modern pragma once
+#pragma once

--- a/zone/account_zone.hh
+++ b/zone/account_zone.hh
@@ -18,7 +18,7 @@
  * Chart of Accounts entry/edit/list module
  */
 
-#pragma once  // REFACTOR: Replaced #ifndef _ACCOUNT_ZONE_HH guard with modern pragma once
+#pragma once
 
 #include "form_zone.hh"
 

--- a/zone/creditcard_list_zone.hh
+++ b/zone/creditcard_list_zone.hh
@@ -18,7 +18,7 @@
  * Touch zone for managing credit cards
  */
 
-#pragma once  // REFACTOR: Replaced #ifndef CREDITCARD_LIST_ZONE_HH guard with modern pragma once
+#pragma once
 
 #include "form_zone.hh"
 #include "credit.hh"

--- a/zone/dialog_zone.hh
+++ b/zone/dialog_zone.hh
@@ -18,7 +18,7 @@
  * Zone dialog box classes
  */
 
-#pragma once  // REFACTOR: Replaced #ifndef _DIALOG_ZONE_HH guard with modern pragma once
+#pragma once
 
 #include "check.hh"
 #include "layout_zone.hh"
@@ -66,7 +66,7 @@ public:
     Str message;
     int color;
 
-    ButtonObj(const char* text, const genericChar* message = nullptr);  // REFACTOR: Changed NULL to nullptr for modern C++
+    ButtonObj(const char* text, const genericChar* message = nullptr);
 
     int Render(Terminal *term);
     int SetLabel(const char* newlabel) { return label.Set(newlabel); }
@@ -95,14 +95,14 @@ public:
     Zone        *Copy()
     {
         printf("Error:  No DialogZone::Copy() method defined for subclass!\n");
-        return nullptr;     // REFACTOR: Changed NULL to nullptr for modern C++
+        return nullptr;
     }
     int Type() { return ZONE_DLG_UNKNOWN; }
     RenderResult Render(Terminal *term, int update_flag);
     SignalResult Touch(Terminal *term, int tx, int ty);
     SignalResult Mouse(Terminal *term, int action, int mx, int my);
 
-    ButtonObj *Button(const char* text, const genericChar* message = nullptr);  // REFACTOR: Changed NULL to nullptr for modern C++
+    ButtonObj *Button(const char* text, const genericChar* message = nullptr);
     int ClosingAction(int action_type, int action, int arg);
     int ClosingAction(int action_type, int action, const char* message);
     int SetAllActions(DialogZone *dest);

--- a/zone/form_zone.cc
+++ b/zone/form_zone.cc
@@ -333,7 +333,7 @@ int TemplatePos(const genericChar* temp, int cursor)
 // Constructor
 FormZone::FormZone()
 {
-    keyboard_focus = nullptr; // REFACTOR: NULL -> nullptr for modern C++
+    keyboard_focus = nullptr;
     record_no      = 0;
     keep_focus     = 1;
     wrap           = 1;
@@ -359,7 +359,7 @@ RenderResult FormZone::Render(Terminal *term, int update_flag)
     }
 
     if (update_flag || keep_focus == 0)
-        keyboard_focus = nullptr; // REFACTOR: NULL -> nullptr for modern C++
+        keyboard_focus = nullptr;
 	
 
     LayoutZone::Render(term, update_flag);
@@ -379,7 +379,7 @@ RenderResult FormZone::Render(Terminal *term, int update_flag)
 
     LayoutForm(term);
 
-    for (FormField *f = FieldList(); f != nullptr; f = f->next) // REFACTOR: NULL -> nullptr for modern C++
+    for (FormField *f = FieldList(); f != nullptr; f = f->next)
     {
         f->selected = (keyboard_focus == f);
         if (f->active)
@@ -401,7 +401,7 @@ SignalResult FormZone::Signal(Terminal *term, const genericChar* message)
 
     // initial decisions; put these here so we don't have to duplicate them for
     // various cases below
-    if (keyboard_focus == nullptr && idx < 14) // REFACTOR: NULL -> nullptr for modern C++
+    if (keyboard_focus == nullptr && idx < 14)
     {
         // don't handle numeric keypad if we don't have any fields selected
         return SIGNAL_IGNORED;
@@ -487,7 +487,7 @@ SignalResult FormZone::Signal(Terminal *term, const genericChar* message)
             LoadRecord(term, record_no);
         break;
     case 22:  // Print
-        if (p == nullptr || e == nullptr) // REFACTOR: NULL -> nullptr for modern C++
+        if (p == nullptr || e == nullptr)
             return SIGNAL_IGNORED;
         SaveRecord(term, record_no, 0);
         if (PrintRecord(term, record_no))
@@ -609,7 +609,7 @@ SignalResult FormZone::Keyboard(Terminal *term, int my_key, int state)
 int FormZone::Add(FormField *fe)
 {
     FnTrace("FormZone::Add()");
-    if (fe == nullptr) // REFACTOR: NULL -> nullptr for modern C++
+    if (fe == nullptr)
         return 1; // Error
 
     field_list.AddToTail(fe);
@@ -754,7 +754,7 @@ int FormZone::RightAlign()
 int FormZone::Remove(FormField *f)
 {
     FnTrace("FormZone::Remove()");
-    if (f == nullptr) // REFACTOR: NULL -> nullptr for modern C++
+    if (f == nullptr)
         return 1;
 
     return field_list.Remove(f);
@@ -818,7 +818,7 @@ int FormZone::LayoutForm(Terminal *term)
 FormField *FormZone::Find(Flt px, Flt py)
 {
     FnTrace("FormZone::Find()");
-    for (FormField *fe = FieldList(); fe != nullptr; fe = fe->next) // REFACTOR: NULL -> nullptr for modern C++
+    for (FormField *fe = FieldList(); fe != nullptr; fe = fe->next)
     {
         if (fe->active && fe->modify &&
             py >= (fe->y -.5) && py <= (fe->y + fe->h -.5) &&
@@ -827,19 +827,19 @@ FormField *FormZone::Find(Flt px, Flt py)
             return fe;
         }
     }
-    return nullptr; // REFACTOR: NULL -> nullptr for modern C++
+    return nullptr;
 }
 
 int FormZone::NextField()
 {
     FnTrace("FormZone::NextField()");
-    if (keyboard_focus == nullptr) // REFACTOR: NULL -> nullptr for modern C++
+    if (keyboard_focus == nullptr)
         return FirstField();
 
     do
     {
         keyboard_focus = keyboard_focus->next;
-        if (keyboard_focus == nullptr) // REFACTOR: NULL -> nullptr for modern C++
+        if (keyboard_focus == nullptr)
             return FirstField();
     }
     while (keyboard_focus->modify == 0 || keyboard_focus->active == 0);
@@ -849,13 +849,13 @@ int FormZone::NextField()
 int FormZone::ForeField()
 {
     FnTrace("FormZone::ForeField()");
-    if (keyboard_focus == nullptr) // REFACTOR: NULL -> nullptr for modern C++
+    if (keyboard_focus == nullptr)
         return LastField();
 
     do
     {
         keyboard_focus = keyboard_focus->fore;
-        if (keyboard_focus == nullptr) // REFACTOR: NULL -> nullptr for modern C++
+        if (keyboard_focus == nullptr)
             return LastField();
     }
     while (keyboard_focus->modify == 0 || keyboard_focus->active == 0);
@@ -1035,7 +1035,7 @@ SignalResult ListFormZone::Signal(Terminal *term, const genericChar* message)
             LoadRecord(term, record_no);
         break;
     case 6:  // Print
-        if (p == nullptr || e == nullptr) // REFACTOR: NULL -> nullptr for modern C++
+        if (p == nullptr || e == nullptr)
             return SIGNAL_IGNORED;
         if (show_list)
         {
@@ -1671,7 +1671,7 @@ int TextField::Append(genericChar* my_string)
 int TextField::Append(Str &my_string)
 {
     FnTrace("TextField::Append()");
-    genericChar* tbuff = nullptr; // REFACTOR: NULL -> nullptr for modern C++
+    genericChar* tbuff = nullptr;
     int retval = 0;
     int numdigits = 1;
 

--- a/zone/form_zone.hh
+++ b/zone/form_zone.hh
@@ -18,7 +18,7 @@
  * base touch zone for data entry and display
  */
 
-#pragma once  // REFACTOR: Replaced #ifndef _FORM_ZONE_HH guard with modern pragma once
+#pragma once
 
 #include "layout_zone.hh"
 #include "report.hh"

--- a/zone/hardware_zone.hh
+++ b/zone/hardware_zone.hh
@@ -18,7 +18,7 @@
  * Hardware settings (taken from settings_zone.hh)
  */
 
-#pragma once  // REFACTOR: Replaced #ifndef _HARDWARE_ZONE_HH guard with modern pragma once
+#pragma once
 
 #include "form_zone.hh"
 

--- a/zone/layout_zone.hh
+++ b/zone/layout_zone.hh
@@ -18,7 +18,7 @@
  * base class zone object for display layout
  */
 
-#pragma once  // REFACTOR: Replaced #ifndef _LAYOUT_ZONE_HH guard with modern pragma once
+#pragma once
 
 #include "pos_zone.hh"
 #include "terminal.hh"
@@ -74,7 +74,7 @@ public:
     int LinePos(Terminal *t, Flt row, Flt line, Flt len,
                 int color = COLOR_DEFAULT);
 
-    int Entry(Terminal *t, Flt px, Flt py, Flt len, RegionInfo *place = nullptr);  // REFACTOR: Changed NULL to nullptr for modern C++
+    int Entry(Terminal *t, Flt px, Flt py, Flt len, RegionInfo *place = nullptr);
     int Button(Terminal *t, Flt px, Flt py, Flt len, int lit = 0);
     int Background(Terminal *t, Flt line, Flt h, int texture);
     int Raised(Terminal *t, Flt line, Flt h);

--- a/zone/merchant_zone.hh
+++ b/zone/merchant_zone.hh
@@ -18,7 +18,7 @@
  * Credit/Debit Card merchant authorization infomation entry zone
  */
 
-#pragma once  // REFACTOR: Replaced #ifndef _MERCHANT_ZONE_HH guard with modern pragma once
+#pragma once
 
 #include "form_zone.hh"
 

--- a/zone/payout_zone.hh
+++ b/zone/payout_zone.hh
@@ -18,7 +18,7 @@
  * Definition of captured tip payouts
  */
 
-#pragma once  // REFACTOR: Replaced #ifndef _PAYOUT_ZONE_HH guard with modern pragma once
+#pragma once
 
 #include "layout_zone.hh"
 

--- a/zone/report_zone.hh
+++ b/zone/report_zone.hh
@@ -18,7 +18,7 @@
  * Definition of report information display zone
  */
 
-#pragma once  // REFACTOR: Replaced #ifndef _REPORT_ZONE_HH guard with modern pragma once
+#pragma once
 
 #include "layout_zone.hh"
 #include "report.hh"

--- a/zone/search_zone.hh
+++ b/zone/search_zone.hh
@@ -17,7 +17,7 @@
  * search_zone.hh - revision 1 (10/13/98)
  */
 
-#pragma once  // REFACTOR: Replaced #ifndef _SEARCH_ZONE_HH guard with modern pragma once
+#pragma once
 
 #include "layout_zone.hh"
 

--- a/zone/settings_zone.cc
+++ b/zone/settings_zone.cc
@@ -2115,7 +2115,7 @@ int TenderSetZone::KillRecord(Terminal *term, int record)
     {
         DiscountInfo *ds = settings->FindDiscountByRecord(record);
         ds->active = 0;
-        if (ds->next != nullptr) // REFACTOR: NULL -> nullptr for modern C++
+        if (ds->next != nullptr)
             display_id = ds->next->id;
         else
             record_no = -1;
@@ -2180,7 +2180,7 @@ int TenderSetZone::UpdateForm(Terminal *term, int record)
 {
     FnTrace("TenderSetZone::UpdateForm()");
     int retval = 0;
-    FormField *field = nullptr; // REFACTOR: NULL -> nullptr for modern C++
+    FormField *field = nullptr;
     int is_item_specific = 0;
     int is_active = 0;
     static int last_family = -1;
@@ -2201,7 +2201,7 @@ int TenderSetZone::UpdateForm(Terminal *term, int record)
         field = field->next;
         if (is_item_specific)
             is_active = 1;
-        while (field != nullptr && field != creditcard_start) // REFACTOR: NULL -> nullptr for modern C++
+        while (field != nullptr && field != creditcard_start)
         {
             field->active = is_active;
             field = field->next;
@@ -2282,7 +2282,7 @@ int TenderSetZone::ItemList(FormField *itemfield, int family, int item_id)
     if (items->ItemsInFamily(family) > 0)
     {
         itemfield->AddEntry(ALL_ITEMS_STRING, -1);
-        while (item != nullptr) // REFACTOR: NULL -> nullptr for modern C++
+        while (item != nullptr)
         {
             if (item->family == family)
             {

--- a/zone/table_zone.hh
+++ b/zone/table_zone.hh
@@ -18,7 +18,7 @@
  * Table page & table control zone objects
  */
 
-#pragma once  // REFACTOR: Replaced #ifndef _TABLE_ZONE_HH guard with modern pragma once
+#pragma once
 
 #include "check.hh"
 #include "customer.hh"

--- a/zone/user_edit_zone.hh
+++ b/zone/user_edit_zone.hh
@@ -18,7 +18,7 @@
  * Zone for editing users & job security information
  */
 
-#pragma once  // REFACTOR: Replaced #ifndef _USER_EDIT_ZONE_HH guard with modern pragma once
+#pragma once
 
 #include "form_zone.hh"
 

--- a/zone/video_zone.hh
+++ b/zone/video_zone.hh
@@ -19,7 +19,7 @@
  *  to determine which food types get sent to the Kitchen Video reports.
  */
 
-#pragma once  // REFACTOR: Added modern pragma once for include protection
+#pragma once
 
 #define VIDEO_TARGET_NORMAL  0
 #define VIDEO_TARGET_KITCHEN 1

--- a/zone/zone.cc
+++ b/zone/zone.cc
@@ -1290,7 +1290,7 @@ int ZoneDB::ExportPage(Page *page)
         return retval;
 
     MasterSystem->FullPath(PAGEEXPORTS_DIR, fullpath);
-    EnsureFileExists(fullpath);
+    EnsureDirExists(fullpath);
     snprintf(filepath, STRLONG, "/page_%d", page->id);
     strncat(fullpath, filepath, sizeof(fullpath) - strlen(fullpath) - 1);
     if (outfile.Open(fullpath, ZONE_VERSION) == 0)

--- a/zone/zone.hh
+++ b/zone/zone.hh
@@ -6,7 +6,7 @@
  * Functions for managing zones on a view
  */
 
-#pragma once  // REFACTOR: Replaced #ifndef _ZONE_HH guard with modern pragma once
+#pragma once
 
 #include "utility.hh"
 #include "list_utility.hh"
@@ -199,32 +199,32 @@ public:
     // boolean - can zone be copied/moved/deleted?
 
     virtual int ZoneStates() { return 2; }
-    virtual SalesItem *Item(ItemDB *db) { return nullptr; }   // REFACTOR: Changed NULL to nullptr for modern C++
+    virtual SalesItem *Item(ItemDB *db) { return nullptr; }
 
     // Interface for zone settings (FIX - should be moved to pos_zone module)
-    virtual int   *Amount()          { return nullptr; }   // REFACTOR: Changed NULL to nullptr for modern C++
-    virtual Str   *Expression()      { return nullptr; }   // REFACTOR: Changed NULL to nullptr for modern C++
-    virtual Str   *FileName()        { return nullptr; }   // REFACTOR: Changed NULL to nullptr for modern C++
-    virtual Str   *ItemName()        { return nullptr; }   // REFACTOR: Changed NULL to nullptr for modern C++
-    virtual int   *JumpType()        { return nullptr; }   // REFACTOR: Changed NULL to nullptr for modern C++
-    virtual int   *JumpID()          { return nullptr; }   // REFACTOR: Changed NULL to nullptr for modern C++
-    virtual Str   *Message()         { return nullptr; }   // REFACTOR: Changed NULL to nullptr for modern C++
-    virtual int   *QualifierType()   { return nullptr; }   // REFACTOR: Changed NULL to nullptr for modern C++
-    virtual int   *ReportType()      { return nullptr; }   // REFACTOR: Changed NULL to nullptr for modern C++
-    virtual int   *ReportPrint()     { return nullptr; }   // REFACTOR: Changed NULL to nullptr for modern C++
-    virtual Str   *Script()          { return nullptr; }   // REFACTOR: Changed NULL to nullptr for modern C++
-    virtual Flt   *Spacing()         { return nullptr; }   // REFACTOR: Changed NULL to nullptr for modern C++
-    virtual int   *SwitchType()      { return nullptr; }   // REFACTOR: Changed NULL to nullptr for modern C++
-    virtual int   *TenderType()      { return nullptr; }   // REFACTOR: Changed NULL to nullptr for modern C++
-    virtual int   *TenderAmount()    { return nullptr; }   // REFACTOR: Changed NULL to nullptr for modern C++
-    virtual int   *Columns()         { return nullptr; }   // REFACTOR: Changed NULL to nullptr for modern C++
-    virtual int   *CustomerType()    { return nullptr; }   // REFACTOR: Changed NULL to nullptr for modern C++
-    virtual Check *GetCheck()      { return nullptr; }   // REFACTOR: Changed NULL to nullptr for modern C++
-    virtual int   *CheckDisplayNum() { return nullptr; }   // REFACTOR: Changed NULL to nullptr for modern C++
-    virtual int   *VideoTarget()     { return nullptr; }   // REFACTOR: Changed NULL to nullptr for modern C++
-    virtual int   *DrawerZoneType()  { return nullptr; }   // REFACTOR: Changed NULL to nullptr for modern C++
-    virtual int   *Confirm()         { return nullptr; }   // REFACTOR: Changed NULL to nullptr for modern C++
-    virtual Str   *ConfirmMsg()      { return nullptr; }   // REFACTOR: Changed NULL to nullptr for modern C++
+    virtual int   *Amount()          { return nullptr; }
+    virtual Str   *Expression()      { return nullptr; }
+    virtual Str   *FileName()        { return nullptr; }
+    virtual Str   *ItemName()        { return nullptr; }
+    virtual int   *JumpType()        { return nullptr; }
+    virtual int   *JumpID()          { return nullptr; }
+    virtual Str   *Message()         { return nullptr; }
+    virtual int   *QualifierType()   { return nullptr; }
+    virtual int   *ReportType()      { return nullptr; }
+    virtual int   *ReportPrint()     { return nullptr; }
+    virtual Str   *Script()          { return nullptr; }
+    virtual Flt   *Spacing()         { return nullptr; }
+    virtual int   *SwitchType()      { return nullptr; }
+    virtual int   *TenderType()      { return nullptr; }
+    virtual int   *TenderAmount()    { return nullptr; }
+    virtual int   *Columns()         { return nullptr; }
+    virtual int   *CustomerType()    { return nullptr; }
+    virtual Check *GetCheck()      { return nullptr; }
+    virtual int   *CheckDisplayNum() { return nullptr; }
+    virtual int   *VideoTarget()     { return nullptr; }
+    virtual int   *DrawerZoneType()  { return nullptr; }
+    virtual int   *Confirm()         { return nullptr; }
+    virtual Str   *ConfirmMsg()      { return nullptr; }
 };
 
 class Page
@@ -381,6 +381,6 @@ public:
     int PageListReport(Terminal *t, int show_system, Report *r);
     int ChangeItemName(const char* old_name, const genericChar* new_name);
 
-    int PrintZoneDB(const char* dest = nullptr, int brief = 0);  // REFACTOR: Changed NULL to nullptr for modern C++
+    int PrintZoneDB(const char* dest = nullptr, int brief = 0);
 };
 


### PR DESCRIPTION
## Overview
This PR completes a comprehensive C++17 modernization of the ViewTouch codebase while fixing critical security vulnerabilities and a directory access issue introduced during refactoring.

## 🔧 Critical Fixes
- **Directory Permissions**: Fixed `/usr/viewtouch/dat` becoming inaccessible due to `umask(0111)` removing execute permissions
- **Security**: Eliminated buffer overflow vulnerabilities in UnitAmount, PrintItem, Locale, and Payment classes  
- **Build System**: Resolved compilation errors, linker issues, and 50+ compiler warnings

## 🚀 Modernization Highlights
- **Type Safety**: Converted 200+ `NULL` → `nullptr` and `typedef` → `using` declarations
- **Code Quality**: Added modern `#pragma once` headers and enhanced Str class with C++17 features
- **Test Suite**: Fixed critical test failures and ensured 100% test pass rate

## 📊 Impact
- **Security**: Fixed 4 critical buffer overflow vulnerabilities
- **Compatibility**: Full C++17 standards compliance maintained
- **Backward Compatibility**: ✅ Preserved

## 🧪 Testing
- All unit tests pass
- Build system verified across all executables (vt_main, vt_term, vt_print, vt_cdu)
- Directory permissions verified working