### PR TITLE
Fix vt_data download safety and offline handling

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -100,9 +100,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - **Automatic vt_data Download on Startup**
   - ViewTouch now automatically downloads latest vt_data from update servers on startup
   - Dual URL support with automatic fallback:
-    - Primary: `http://www.viewtouch.com/vt_updates/vt-update`
-    - Fallback: `https://www.viewtouch.com/vt_updates/vt-update`
-  - Always downloads fresh vt_data on every startup (not just when missing)
+    - Primary: `http://www.viewtouch.com/vt_data`
+    - Fallback: `https://www.viewtouch.com/vt_data`
+  - Smart offline handling: Only downloads when local vt_data is missing
+  - **Enhanced Safety**: Downloads to temporary files first, only replaces original on success
+  - **Automatic Backup Cleanup**: Removes old .bak and .bak2 files after successful updates
+  - **Offline Resilience**: System starts normally with existing vt_data when offline
   - Comprehensive error handling and logging for troubleshooting
   - Uses existing robust download infrastructure with timeout handling
 - **Comprehensive Text Enhancement System**


### PR DESCRIPTION
- Fixed critical bug where vt_data was being deleted even when downloads failed
- Implemented temporary file download approach to preserve original files
- Added smart offline detection: only downloads when local vt_data is missing
- Fixed incorrect download URLs (was using vt-update instead of vt_data)
- Enhanced FindVTData() to skip redundant downloads when local file exists
- Added automatic cleanup of old backup files (.bak, .bak2) after successful updates
- System now starts normally offline with existing vt_data
- Comprehensive error handling and logging for troubleshooting