### PR TITLE
Enhanced Kitchen and Bar Video Display Separation with Order Recall

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,18 +6,30 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 ### Added
-- **Complete Kitchen and Bar Video Display Separation**
+- **Complete Kitchen and Bar Video Display Separation with Order Recall**
   - **Independent Status Tracking**: Implemented separate check flags for kitchen and bar video displays
     - `CF_KITCHEN_MADE` (16): Kitchen marks their portion as made/ready
     - `CF_BAR_MADE` (32): Bar marks their portion as made/ready  
     - `CF_KITCHEN_SERVED` (64): Kitchen marks their portion as served
     - `CF_BAR_SERVED` (128): Bar marks their portion as served
-  - **Independent Highlighting**: First tap on a check only affects the current video target (kitchen or bar)
-  - **Independent Serving**: Second tap on a check only removes it from the current video target
+  - **Three-Tap Workflow**: Complete order lifecycle management for each video target
+    - **First Tap**: Marks order as "made" for that video target only
+    - **Second Tap**: Marks order as "served" for that video target only  
+    - **Third Tap**: Recalls the order back to the video display for that target only
+  - **Enhanced Undo Button**: Provides granular control to recall served orders
+    - Finds most recent check served by current video target
+    - Recalls order by clearing target-specific served flag
+    - Only affects current video target, not others
+    - Brings order back to video display for verification
+  - **Complete Video Target Coverage**: Supports all kitchen and bar video displays
+    - Kitchen 1, Kitchen 2, Bar 1, Bar 2 all work independently
+    - Each target maintains separate order status tracking
+    - No cross-interference between any video targets
   - **Complete Workflow Independence**: Kitchen and bar can work without interfering with each other
   - **No Cross-Interference**: Actions on one video target never affect the other
   - Enhanced `ToggleCheckReport` method to use target-specific flags for both highlighting and serving
   - Updated `DisplayCheckReport` method to check appropriate flags for each video target
+  - Modified `UndoRecentCheck` method to provide target-specific order recall
   - Comprehensive documentation in `VIEWTOUCH_IMPROVEMENTS_SUMMARY.md`
 
 - **Fixed Video Target Routing System**


### PR DESCRIPTION
## Overview

This pull request implements enhanced kitchen and bar video display separation with order recall functionality, providing complete independence between departments while maintaining proper order tracking and recall capabilities.

## Key Features

### 🍳 **Complete Kitchen and Bar Video Separation**
- **Independent Status Tracking**: Implemented separate check flags for kitchen and bar video displays
  -  (16): Kitchen marks their portion as made/ready
  -  (32): Bar marks their portion as made/ready  
  -  (64): Kitchen marks their portion as served
  -  (128): Bar marks their portion as served

### 🎯 **Two-Tap Workflow for Complete Order Lifecycle**
- **First Tap**: Marks order as "made" for that video target only
- **Second Tap**: Marks order as "served" for that video target only  

### 🔄 **Enhanced Undo Button with Granular Control**
- **Target-Specific Recall**: Finds most recent check served by current video target
- **Smart Order Recovery**: Recalls order by clearing target-specific served flag
- **No Cross-Interference**: Only affects current video target, not others
- **Verification Support**: Brings order back to video display for staff verification

### 📱 **Complete Video Target Coverage**
- **Kitchen 1, Kitchen 2, Bar 1, Bar 2** all work independently
- Each target maintains separate order status tracking
- No cross-interference between any video targets
- Explicit handling of all video target types

## Technical Implementation

### Files Modified
-  - Enhanced with explicit video target support and order recall
-  - Updated with comprehensive feature documentation

### Key Methods Enhanced
-  - Three-tap workflow with target-specific flag management
-  - Smart order recall by video target
-  - Proper flag checking for each target
-  - Enhanced video target separation logic

### Benefits
- **For Users**: Complete workflow independence, proper order recall, no cross-interference
- **For System**: Better separation, efficient routing, data integrity
- **For Operations**: Improved efficiency, better workflow, reduced errors
- **For Maintainers**: Cleaner code structure, explicit target handling, better maintainability

## Testing
- ✅ All changes compile successfully
- ✅ Proper integration with existing ViewTouch system
- ✅ Maintains backward compatibility
- ✅ Comprehensive testing of all video targets
- ✅ Order recall functionality verified

## Addresses Maintainer Feedback
This implementation directly addresses the previous comment: "You're introducing more granular control to the fulfillment staff. Make sure that the ability to recall a closed order provides for appropriate granular control, too."

The enhanced Undo button now provides:
- **Granular Control**: Each video target can independently recall their served orders
- **Appropriate Separation**: Kitchen and bar operations are completely independent
- **Order Verification**: Staff can recall orders to verify they made all items correctly
- **Target-Specific Behavior**: Actions on one video target never affect others

This ensures that fulfillment staff have complete control over their order workflow while maintaining proper separation between departments.