### PR TITLE
Fix printer duplication bug after ViewTouch restart

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -921,6 +921,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - remove GTK+3 dependency, only used in loader, where we revert to use X11 directly #127
 
 ### Fixed
+- **Printer Duplication Bug**: Fixed critical issue where printers were being duplicated after ViewTouch restart
+  - **Root Cause**: System was creating new "Report Printer" entries on every startup without checking if one already existed
+  - **Problem**: Each restart would add another report printer to settings, causing multiple duplicate entries
+  - **Solution**: Added duplicate check using `settings->FindPrinterByType(PRINTER_REPORT)` before creating new report printers
+  - **Implementation**: Modified report printer creation logic in `StartSystem()` function to reuse existing printers
+  - **Result**: Only one report printer is created and maintained across multiple restarts
+  - **Files Modified**: `main/data/manager.cc` - Enhanced printer initialization with duplicate prevention
+  - **Impact**: Eliminates printer duplication in settings, maintains clean configuration files
 - **Version Number and Date Update**: Updated version number to reflect current year and fixed version date display in Page 1 lower left corner
   - **Version Number**: Updated from "21.05.1" to "25.01.1" to reflect current year 2025
   - **Version Date**: Fixed version date display to show current build date (2025-09-18) instead of cached 2021 date

--- a/main/data/manager.cc
+++ b/main/data/manager.cc
@@ -1214,16 +1214,26 @@ int StartSystem(int my_use_net)
     // Defaults:  print to HTML, file:/<dat dir>/html/
     if (have_report < 1)
     {
-        genericChar prtstr[STRLONG];
-        PrinterInfo *report_printer = new PrinterInfo;
-        report_printer->name.Set("Report Printer");
-        sys->FullPath("html", str);
-        snprintf(prtstr, STRLONG, "file:%s/", str);
-        report_printer->host.Set(prtstr);
-        report_printer->model = MODEL_HTML;
-        report_printer->type = PRINTER_REPORT;
-        settings->Add(report_printer);
-        report_printer->OpenPrinter(MasterControl);
+        // Check if a report printer already exists in settings before creating a new one
+        PrinterInfo *existing_report = settings->FindPrinterByType(PRINTER_REPORT);
+        if (existing_report == NULL)
+        {
+            genericChar prtstr[STRLONG];
+            PrinterInfo *report_printer = new PrinterInfo;
+            report_printer->name.Set("Report Printer");
+            sys->FullPath("html", str);
+            snprintf(prtstr, STRLONG, "file:%s/", str);
+            report_printer->host.Set(prtstr);
+            report_printer->model = MODEL_HTML;
+            report_printer->type = PRINTER_REPORT;
+            settings->Add(report_printer);
+            report_printer->OpenPrinter(MasterControl);
+        }
+        else
+        {
+            // If a report printer exists but wasn't opened (e.g., network issue), try to open it
+            existing_report->OpenPrinter(MasterControl);
+        }
     }
 
     // Add local terminal


### PR DESCRIPTION
- Fixed critical issue where printers were being duplicated after restart
- Root cause: System was creating new 'Report Printer' entries on every startup without checking if one already existed
- Solution: Added duplicate check using settings->FindPrinterByType(PRINTER_REPORT) before creating new report printers
- Modified report printer creation logic in StartSystem() function to reuse existing printers
- Result: Only one report printer is created and maintained across multiple restarts
- Files modified: main/data/manager.cc - Enhanced printer initialization with duplicate prevention
- Impact: Eliminates printer duplication in settings, maintains clean configuration files