### PR TITLE
Self-Order Button Fix and Security Update

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,10 +6,10 @@ The following versions of ViewTouch are currently supported with security update
 
 | Version | Supported          | Notes |
 | ------- | ------------------ | ----- |
-| 21.05.x | :white_check_mark: | Current stable release |
-| 21.04.x | :white_check_mark: | Previous stable release |
-| 21.03.x | :white_check_mark: | Legacy support |
-| < 21.03 | :x:                | End of life |
+| 25.01.x | :white_check_mark: | Current stable release |
+| 25.00.x | :white_check_mark: | Previous stable release |
+| 24.xx.x | :white_check_mark: | Legacy support |
+| < 24.xx | :x:                | End of life |
 
 **Note**: Version support policy is based on the current development cycle. We strive to maintain backward compatibility for all versions where possible. For specific version support status, please contact the maintainers.
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 
 ## [Unreleased]
+### Fixed
+- **Self-Order Button Differentiation**: Fixed issue where `quickdinein` and `quicktogo` buttons on self-order page didn't work correctly
+  - **Problem**: Buttons were calling wrong check types (`CHECK_DINEIN`, `CHECK_TOGO`) instead of self-order variants
+  - **Solution**: Updated message handling to use correct self-order check types (`CHECK_SELFDINEIN`, `CHECK_SELFTAKEOUT`)
+  - **Impact**: Self-order buttons now properly differentiate between dine-in and take-out orders as intended
+  - **Files Modified**: `zone/button_zone.cc` - Fixed message handling in `MessageButtonZone::Signal()` method
+
 ### Added
 - **Enhanced Touchscreen Input System**: Comprehensive improvements to ViewTouch's touchscreen input handling
   - **Enhanced Touch Event Structure**: Added `TouchEvent` struct with timestamp, pressure, and touch ID support for better touch tracking

--- a/zone/button_zone.cc
+++ b/zone/button_zone.cc
@@ -235,12 +235,12 @@ SignalResult MessageButtonZone::Signal(Terminal *term, const char* signal_msg)
 	term->Jump(JUMP_STEALTH, -8);
         break;
     case 3:  // quick to-go
-    	if (term->QuickMode(CHECK_TOGO))
+    	if (term->QuickMode(CHECK_SELFTAKEOUT))
 	    return SIGNAL_IGNORED;
 	term->JumpToIndex(IndexValue[settings->MealPeriod(SystemTime)]);
         break;
     case 4:  // quick dine-in
-    	if (term->QuickMode(CHECK_DINEIN))
+    	if (term->QuickMode(CHECK_SELFDINEIN))
 	    return SIGNAL_IGNORED;
 	term->JumpToIndex(IndexValue[settings->MealPeriod(SystemTime)]);
         break;


### PR DESCRIPTION
### Summary
This PR includes a critical fix for self-order button functionality and updates the security documentation to reflect the current release version.

### Changes Included

#### 🔧 **Self-Order Button Differentiation Fix** (74f5375)
**Problem:** The `quickdinein` and `quicktogo` buttons on the self-order page were not working correctly because they were calling the wrong check types.

**Solution:**
- Fixed `MessageButtonZone::Signal()` to use correct self-order check types
- `quickdinein` now calls `CHECK_SELFDINEIN` instead of `CHECK_DINEIN`
- `quicktogo` now calls `CHECK_SELFTAKEOUT` instead of `CHECK_TOGO`
- Self-order buttons now properly differentiate between dine-in and take-out orders
- Updated changelog.md with fix details

**Files Modified:**
- `zone/button_zone.cc` - Fixed message handling logic
- `docs/changelog.md` - Added documentation for the fix

#### 🔄 **Merge from Upstream** (5c988b3)
- Merged latest changes from ViewTouch:master branch to stay current with upstream development

#### 🔒 **Security Documentation Update** (f4c8354)
- Updated SECURITY.md version numbers to reflect current 25.01.x release
- Ensures security documentation is accurate and up-to-date

### Testing
- ✅ Code builds successfully
- ✅ No breaking changes introduced