### PR TITLE
Add menu item type filtering to Review & Edit Menu Item Properties

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 ### Added
+- **Menu Item Type Filtering in Review & Edit Menu Item Properties**: Enhanced the ItemListZone to allow filtering by specific menu item types
+  - **Filter Buttons**: Added 7 clickable filter buttons at the top of the page (All, Items, Modifiers, Non-Track, Item+Sub, By Weight, Admission)
+  - **Color-Coded Display**: Each of the 6 menu item types now has a unique color for easy visual differentiation:
+    - Regular Items: Default/Black
+    - Modifiers: Dark Blue
+    - Non-Tracking Modifiers: Dark Green
+    - Items + Substitute: Dark Red
+    - Priced By Weight: Purple
+    - Event Admission: Orange
+  - **Smart Filtering**: When a filter is active, only items of that type are displayed, record count updates accordingly, and navigation works within the filtered set
+  - **Visual Indicators**: Active filter button is highlighted, providing clear feedback on current filter state
+  - **Files Modified**:
+    - `zone/inventory_zone.hh` - Added filter_type member, Signal/Mouse method overrides, and helper methods for color/name mapping
+    - `zone/inventory_zone.cc` - Implemented filtering logic in Render, RecordCount, LoadRecord, ListReport, and mouse click detection
+  - **Benefits**:
+    - **Reduced Clutter**: Users can focus on one type of menu item at a time without distraction from other types
+    - **Faster Workflow**: No need to scroll through all items to find specific types; filtering shows only relevant items
+    - **Better Organization**: Useful for viewing and editing specific categories like only modifiers or only admission tickets
+    - **Maintains Compatibility**: All existing functionality works as before when "All" filter is active (default)
+
 - **Modern C++17/20 Improvements to Check Management System**: Comprehensive modernization of the core check handling classes
   - **Memory Management**: Replaced raw `new`/`delete` with `std::make_unique<>()` and smart pointers for better memory safety
   - **Constructor Modernization**: Converted all constructors to use member initializer lists for improved performance and initialization order

--- a/docs/user/ITEMLIST_FILTER_FEATURE.md
+++ b/docs/user/ITEMLIST_FILTER_FEATURE.md
@@ -1,0 +1,100 @@
+# ItemListZone Filter Feature Implementation
+
+## Overview
+
+Enhanced the "Review & Edit Menu Item Properties" page (Admin Index > Operations) to include filtering functionality that allows users to view only specific types of menu items, rather than viewing all types at once.
+
+## Changes Made
+
+### Files Modified
+
+1. **zone/inventory_zone.hh**
+   - Added `filter_type` member variable to track current filter state (-1 = show all, or specific ITEM_* type)
+   - Added `Signal()` method override to handle filter button interactions
+   - Added `Mouse()` method override to handle mouse clicks on filter buttons
+   - Added helper methods:
+     - `GetItemTypeColor()` - Returns unique color for each item type
+     - `GetItemTypeName()` - Returns display name for each item type
+
+2. **zone/inventory_zone.cc**
+   - **Constructor**: Initialize `filter_type` to -1 (show all items by default)
+   
+   - **Render()**: Enhanced to display 7 filter buttons at the top of the page:
+     - All (black)
+     - Items (default color)
+     - Modifiers (dark blue)
+     - Non-Track (dark green)
+     - Item+Sub (dark red)
+     - By Weight (purple)
+     - Event Admission (orange)
+   
+   - **RecordCount()**: Modified to count only items matching the current filter
+   
+   - **LoadRecord()**: Modified to load the nth record of the filtered type
+   
+   - **ListReport()**: Modified to display only items matching the current filter, with color-coded text
+   
+   - **Signal()**: Handles filter change signals (kept for API compatibility)
+   
+   - **Mouse()**: Detects clicks on filter buttons and changes the active filter
+   
+   - **GetItemTypeColor()**: Maps each of the 6 item types to a unique color
+   
+   - **GetItemTypeName()**: Returns user-friendly names for each item type
+
+## Feature Functionality
+
+### Filter Buttons
+
+Seven clickable buttons are displayed at the top of the ItemListZone:
+
+1. **All** - Shows all menu items (default)
+2. **Items** - Shows only regular menu items (ITEM_NORMAL)
+3. **Modifiers** - Shows only modifiers (ITEM_MODIFIER)
+4. **Non-Track** - Shows only non-tracking modifiers (ITEM_METHOD)
+5. **Item+Sub** - Shows only items with substitute (ITEM_SUBSTITUTE)
+6. **By Weight** - Shows only items priced by weight (ITEM_POUND)
+7. **Admission** - Shows only event admission items (ITEM_ADMISSION)
+
+### Visual Indicators
+
+- Active filter button is highlighted/lit
+- Each item type is displayed in its unique color throughout the list
+- Record count reflects only the filtered items
+- Status text shows the current filter and count (e.g., "Modifiers 5 of 12")
+
+### Color Scheme
+
+- **Regular Items**: Default/Black
+- **Modifiers**: Dark Blue
+- **Non-Tracking Modifiers**: Dark Green
+- **Items + Substitute**: Dark Red
+- **Priced By Weight**: Purple
+- **Event Admission**: Orange
+
+## Benefits
+
+1. **Reduced Clutter**: Users can focus on specific item types without distraction
+2. **Easier Navigation**: Faster to find and edit items of a specific type
+3. **Visual Differentiation**: Color-coding helps quickly identify item types
+4. **Maintained Compatibility**: All existing functionality remains intact when "All" filter is active
+5. **Intuitive UI**: Clear button interface for switching between filters
+
+## Testing
+
+The implementation has been successfully compiled and is ready for testing in the ViewTouch application. To test:
+
+1. Build and install: `sudo make install`
+2. Launch ViewTouch: `sudo /usr/viewtouch/bin/vtpos`
+3. Navigate to Admin Index > Operations > Review & Edit Menu Item Properties
+4. Click on the filter buttons at the top to switch between different item type views
+5. Verify that only items of the selected type are shown
+6. Verify that the item count and record navigation work correctly for filtered views
+
+## Implementation Notes
+
+- The filter state is not persisted between sessions (resets to "All" when reopening the page)
+- Filter buttons use standard LayoutZone button rendering for consistency
+- Mouse click detection accounts for proper font metrics and positioning
+- All modifications follow existing ViewTouch coding patterns and conventions
+

--- a/zone/inventory_zone.hh
+++ b/zone/inventory_zone.hh
@@ -132,6 +132,7 @@ public:
 class ItemListZone : public ListFormZone
 {
     unsigned long phrases_changed;
+    int filter_type;  // -1 = show all, or specific ITEM_* type to filter
 public:
     int name_change;
 
@@ -142,6 +143,8 @@ public:
     int          Type() { return ZONE_ITEM_LIST; }
     int          AddFields();
     RenderResult Render(Terminal *t, int update_flag);
+    SignalResult Signal(Terminal *t, const genericChar* message);
+    SignalResult Mouse(Terminal *t, int action, int mx, int my);
     Flt         *Spacing() { return &list_spacing; }
 
     int LoadRecord(Terminal *t, int record);
@@ -149,6 +152,10 @@ public:
     int Search(Terminal *t, int record, const genericChar* word);
     int ListReport(Terminal *t, Report *r);
     int RecordCount(Terminal *t);
+    
+    // Helper functions for filtering
+    int GetItemTypeColor(int item_type);
+    const genericChar* GetItemTypeName(int item_type);
 };
 
 class InvoiceZone : public ListFormZone


### PR DESCRIPTION
- Added filter buttons for 7 categories: All, Items, Modifiers, Non-Track, Item+Sub, By Weight, and Admission
- Each menu item type now displayed in unique color for easy identification
- Filtering updates record count and navigation to work within filtered set
- Active filter button is highlighted for clear visual feedback
- Maintains backward compatibility with default 'All' filter active

Benefits:
- Reduces clutter by showing only items of selected type
- Faster workflow for viewing/editing specific item categories
- Better organization for large menu configurations
- Color-coded display improves visual differentiation

Files modified:
- zone/inventory_zone.hh - Added filter state and helper methods
- zone/inventory_zone.cc - Implemented filtering logic
- docs/changelog.md - Documented new feature
- docs/user/ITEMLIST_FILTER_FEATURE.md - Detailed feature documentation