### PR TITLE
Fix Jekyll build error: wrap C++ JSON code with raw tags

### DIFF
--- a/docs/MODERN_CPP.md
+++ b/docs/MODERN_CPP.md
@@ -252,6 +252,7 @@ if (cfg.Save(true, true)) {  // pretty print + backup
 
 ### Direct JSON Usage
 
+{% raw %}
 ```cpp
 // Create JSON object
 vt::json data = {
@@ -282,6 +283,7 @@ std::string json_str = data.dump(4);  // Pretty print, 4-space indent
 // Parse from string
 auto j = vt::json::parse(R"({"key": "value"})");
 ```
+{% endraw %}
 
 ### Convenience Functions
 


### PR DESCRIPTION
- Added {% raw %} and {% endraw %} around code block containing double curly braces to prevent Liquid syntax interpretation
- Fixes GitHub Pages build failure in CI/CD pipeline