### PR TITLE
fix: Restore Hardware button display sending functionality

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -65,6 +65,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
   - Files modified: `term/layer.{hh,cc}`, `term/term_view.hh`, `main/ui/labels.cc`
 
 ### Fixed
+- **Hardware Button Display Sending**: Fixed broken signal routing for "Hardware" button types that send to display terminals
+  - **Root Cause**: Commit 4d990d86 (2016) introduced strict `z->group_id == group_id` matching that broke broadcast signals
+  - **Issue**: Buttons configured to send to all hardware terminals (group_id = 0) could only reach zones with group_id = 0
+  - **Fix**: Restored proper broadcast logic with `(group_id == 0 || z->group_id == group_id)`
+  - **Impact**: Hardware buttons now correctly send to customer displays, kitchen terminals, and other devices
+  - Files modified: `zone/zone.cc`
 - **Thermal Printer Receipt Centering**: Fixed receipt content alignment on thermal printers
   - Changed Epson printer width from 33 to 40 characters for proper centering
   - Resolves issue where receipt content appeared left-aligned instead of centered

--- a/zone/zone.cc
+++ b/zone/zone.cc
@@ -802,7 +802,7 @@ SignalResult Page::Signal(Terminal *t, const genericChar* message, int group_id)
         {
             if (z->AcceptSignals() &&
                 z->active &&
-                z->group_id == group_id)
+                (group_id == 0 || z->group_id == group_id))
             {
                 res = z->Signal(t, message);
                 switch (res)


### PR DESCRIPTION
- Fixed broken signal routing that prevented Hardware buttons from sending to display terminals
- Root cause: Commit 4d990d86 (2016) introduced strict group_id matching that broke broadcast signals (group_id = 0)
- Changed Page::Signal logic from 'z->group_id == group_id' to '(group_id == 0 || z->group_id == group_id)'
- This restores proper broadcast functionality while maintaining targeted signal routing
- Hardware buttons now correctly send to customer displays, kitchen terminals, and other devices

Files: zone/zone.cc, docs/changelog.md