### PR TITLE
Improve edit drag performance with overlay preview

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -46,6 +46,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
   - **Persistence**: Stored global preference in settings data (`show_button_images_default`) with `SETTINGS_VERSION` bumped to 103
     - Load/Save logic reads and writes the persisted flag
   - Files modified: `main/data/settings.{hh,cc}`, `zone/settings_zone.cc`, `main/ui/labels.cc`, `main/hardware/terminal.cc`
+- **🚀 Edit Mode Drag Performance (2025-11-08)**
+  - **Deferred Rendering**: Suspending full page redraws while dragging zones now relies on a lightweight overlay preview for immediate feedback
+  - **Preview Overlay**: The editor draws a dynamic drag rectangle so button moves stay responsive even while the cursor is in motion, even for multi-zone selections
+  - **Minimal Repaint Path**: Continuous drag updates now mutate an off-screen region accumulator instead of forcing zone re-rendering and pixmap uploads each mouse move
+  - **Final Commit**: Zone positions only redraw once at drop time, keeping X11 smooth and eliminating freeze-like behavior when moving image-heavy buttons
+  - **Shadow Awareness**: Drag preview and final redraw take zone shadows into account so what you see during the move precisely matches the drop result
+  - Files modified: `main/hardware/terminal.{hh,cc}`, `zone/zone.{hh,cc}`
 
 - **📋 Dialog Menu Multi-Column Layout for Long Lists (2025-11-04)**
   - **Multi-Column Display**: Button properties dialogs with more than 8 options now automatically display in multiple columns instead of going off-screen

--- a/main/hardware/terminal.hh
+++ b/main/hardware/terminal.hh
@@ -415,6 +415,11 @@ public:
     int   select_y1;
     int   select_x2;
     int   select_y2;
+    bool  edit_drag_active;
+    int   edit_drag_total_dx;
+    int   edit_drag_total_dy;
+    RegionInfo edit_drag_initial_region;
+    RegionInfo edit_drag_current_region;
 
     // Language settings
     int   current_language;  // current UI language (LANG_ENGLISH, LANG_FRENCH, etc.)
@@ -581,6 +586,7 @@ public:
     int RenderZone(Zone *z);
     int RedrawZone(Zone *z, int time);
     int RenderEditCursor(int x, int y, int w, int h);
+    void DrawZoneDragPreview(const RegionInfo &region);
     int RenderButton(int x, int y, int w, int h,
                      int frame, int texture, int shape = SHAPE_RECTANGLE);
     int RenderShadow(int x, int y, int w, int h, int s, int shape);
@@ -603,6 +609,11 @@ public:
     int MouseInput(int action, int x, int y);
     int MouseToolbar(int action, int x, int y);
     int SizeToMouse();
+
+    bool BeginZoneDragPreview();
+    bool AddZoneDragDelta(int dx, int dy);
+    void EndZoneDragPreview(bool apply_move);
+    bool HasActiveZoneDrag() const noexcept { return edit_drag_active; }
 
     int ButtonCommand(int command);
     int EditZone(Zone *z);

--- a/zone/zone.cc
+++ b/zone/zone.cc
@@ -1599,6 +1599,34 @@ int ZoneDB::SizeEdit(Terminal *t, int wchange, int hchange,
     return 0;
 }
 
+int ZoneDB::GetEditRegion(Terminal *t, RegionInfo &region, int include_shadow)
+{
+    FnTrace("ZoneDB::GetEditRegion()");
+    RegionInfo r;
+    int count = 0;
+
+    Page *p = t ? t->page : nullptr;
+    while (p)
+    {
+        for (Zone *z = p->ZoneList(); z != nullptr; z = z->next)
+        {
+            if (z->edit)
+            {
+                int shadow = include_shadow ? z->ShadowVal(t) : 0;
+                r.Fit(z->x, z->y, z->w + shadow, z->h + shadow);
+                ++count;
+            }
+        }
+        p = p->parent_page;
+    }
+
+    if (count == 0)
+        return 0;
+
+    region = r;
+    return 1;
+}
+
 int ZoneDB::PositionEdit(Terminal *t, int xchange, int ychange)
 {
     FnTrace("ZoneDB::PositionEdit()");

--- a/zone/zone.hh
+++ b/zone/zone.hh
@@ -363,6 +363,7 @@ public:
     // changes size of marked zones
     // position is adjusted accordingly if move_x or move_y are non-zero
     int PositionEdit(Terminal *t, int xchange, int ychange);
+    int GetEditRegion(Terminal *t, RegionInfo &region, int include_shadow = 1);
     // changes position of marged zones
     int CopyEdit(Terminal *t, int modify_x = 0, int modify_y = 0);
     // copies all marked zones to page


### PR DESCRIPTION
- **🚀 Edit Mode Drag Performance (2025-11-08)**
  - **Deferred Rendering**: Suspending full page redraws while dragging zones now relies on a lightweight overlay preview for immediate feedback
  - **Preview Overlay**: The editor draws a dynamic drag rectangle so button moves stay responsive even while the cursor is in motion, even for multi-zone selections
  - **Minimal Repaint Path**: Continuous drag updates now mutate an off-screen region accumulator instead of forcing zone re-rendering and pixmap uploads each mouse move
  - **Final Commit**: Zone positions only redraw once at drop time, keeping X11 smooth and eliminating freeze-like behavior when moving image-heavy buttons
  - **Shadow Awareness**: Drag preview and final redraw take zone shadows into account so what you see during the move precisely matches the drop result
  - Files modified: `main/hardware/terminal.{hh,cc}`, `zone/zone.{hh,cc}`