### PR TITLE
Fix double modifier decimal multiplier handling

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ## [Unreleased]
 
 ### Fixed
+- **Double Modifier Decimal Multiplier (2025-11-11)**
+  - **Issue**: Developer settings rejected fractional double multipliers, causing charges to ignore decimal values when combining multiply and add/subtract adjustments
+  - **Fix**: `double_mult` now stores a floating-point multiplier with proper rounding, allowing values like 1.5 or 0.75 to work alongside `double_add`
+    - Updated `Settings` serialization to version 104 with backward compatibility for legacy integer values
+    - Adjusted `SalesItem::Price()` to compute the final price using floating-point math with cent rounding
+    - Developer settings UI accepts and displays decimal multipliers without truncation
+  - **Impact**: Fractional double pricing now calculates correctly for decimal multipliers and additive/subtractive adjustments
+  - Files modified: `main/business/sales.cc`, `main/data/settings.{hh,cc}`, `zone/settings_zone.cc`, `docs/changelog.md`
 - **Tax Calculation Including Modifiers (2025-11-05)**
   - **Issue**: Tax calculation was inconsistent between main checkout system and per-order display
   - **Root Cause**: `Order::CalculateTax()` used `cost` (excluding modifiers) while main system used `total_cost` (including modifiers)

--- a/main/business/sales.cc
+++ b/main/business/sales.cc
@@ -31,6 +31,7 @@
 #include "src/utils/vt_logger.hh"
 
 #include <cctype>
+#include <cmath>
 #include <string.h>
 
 #ifdef DMALLOC
@@ -345,8 +346,11 @@ int SalesItem::Price(Settings *s, int qualifier)
 
     if (qualifier & QUALIFIER_DOUBLE)
     {
-        c *= s->double_mult;
-        c += s->double_add;
+        const double base = static_cast<double>(c);
+        const double multiplier = static_cast<double>(s->double_mult);
+        const double additive = static_cast<double>(s->double_add);
+        const double adjusted = base * multiplier + additive;
+        c = static_cast<int>(std::lround(adjusted));
     }
 
     if (c < 0)

--- a/main/data/settings.cc
+++ b/main/data/settings.cc
@@ -1256,7 +1256,7 @@ Settings::Settings()
     store              = 0;
     developer_key      = 123456789; // silly default
     price_rounding     = ROUNDING_NONE;
-    double_mult        = 2;
+    double_mult        = 2.0;
     double_add         = 0;
     combine_accounts   = 1;
     discount_alcohol   = 1;
@@ -1592,7 +1592,19 @@ int Settings::Load(const char* file)
             Add(pi);
         }
     }
-    df.Read(double_mult);
+    if (version >= 104)
+    {
+        if (df.Read(double_mult) != 0)
+            double_mult = 2.0;
+    }
+    else
+    {
+        int legacy_double_mult = 0;
+        if (df.Read(legacy_double_mult) == 0)
+            double_mult = static_cast<Flt>(legacy_double_mult);
+        else
+            double_mult = 2.0;
+    }
     df.Read(double_add);
     df.Read(combine_accounts);
     df.Read(change_for_checks);

--- a/main/data/settings.hh
+++ b/main/data/settings.hh
@@ -30,7 +30,7 @@
 // NOTE:  WHEN UPDATING SETTINGS DO NOT FORGET that you may also
 // need to update archive.hh and archive.cc for settings which
 // should be maintained historically.
-constexpr int SETTINGS_VERSION = 103;  // READ ABOVE
+constexpr int SETTINGS_VERSION = 104;  // READ ABOVE
 
 
 /**** Definitions & Data ****/
@@ -605,7 +605,7 @@ public:
     int store;                   // store code - for company specific features
     int developer_key;           // key code for developer
     int price_rounding;          // cost rounding setting
-    int double_mult;
+    Flt double_mult;
     int double_add;              // how double qualifier effects price
     int combine_accounts;        // boolean - combine tax & revenus accounts?
     int always_open;             // is store 24 hours?


### PR DESCRIPTION
- **Double Modifier Decimal Multiplier (2025-11-11)**
  - **Issue**: Developer settings rejected fractional double multipliers, causing charges to ignore decimal values when combining multiply and add/subtract adjustments
  - **Fix**: `double_mult` now stores a floating-point multiplier with proper rounding, allowing values like 1.5 or 0.75 to work alongside `double_add`
    - Updated `Settings` serialization to version 104 with backward compatibility for legacy integer values
    - Adjusted `SalesItem::Price()` to compute the final price using floating-point math with cent rounding
    - Developer settings UI accepts and displays decimal multipliers without truncation
  - **Impact**: Fractional double pricing now calculates correctly for decimal multipliers and additive/subtractive adjustments
  - Files modified: `main/business/sales.cc`, `main/data/settings.{hh,cc}`, `zone/settings_zone.cc`, `docs/changelog.md`