### PR TITLE
Add new page types and qualifiers for enhanced modifier and navigation

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ## [Unreleased]
 
 ### Added
+- **New Page Types and Qualifiers (11-28-2025)**
+  - **Feature**: Added two new page types to support advanced modifier pages and enhanced navigation
+  - **New Page Types**:
+    - **Modifier Page with Keyboard** (Type 17, Parent -96): A modifier page with pre-positioned empty buttons and keyboard support for creating complex modifier pages with qualifiers (e.g., breakfast egg preparations: Soft Poach, Hard Scramble, Over Easy)
+    - **Index with Tabs** (Type 18, Parent -95): An index page with tab-based navigation that child menu item pages automatically inherit, enabling one-touch navigation between any pages in the system
+  - **New Qualifiers**:
+    - **Easy**: For items prepared with ease (e.g., "Over Easy" eggs)
+    - **Add**: For adding items or ingredients
+    - **Senior Share**: For senior portion sharing options
+  - **Note**: Pages -95 & -96 are currently under development as parent templates for these new page types
+  - **Impact**: Significantly reduces time for editors creating modifier pages with qualifiers and setting up navigation tabs that propagate to all child pages
+  - **Files modified**:
+    - `zone/zone.hh`, `term/term_view.hh` - Added PAGE_MODIFIER_KEYBOARD and PAGE_INDEX_WITH_TABS constants
+    - `main/ui/labels.cc` - Added page type names and qualifier names/values
+    - `zone/zone.cc` - Added parent page relationships for new page types
+    - `main/business/sales.hh` - Added QUALIFIER_EASY, QUALIFIER_ADD, QUALIFIER_SENIORSHARE constants
+    - `main/business/sales.cc` - Added MergeQualifier and PrintItem cases for new qualifiers
+
 - **General Settings Section Navigation (11-24-2025)**
   - **Feature**: Added section-based navigation to General Settings with tab buttons
   - **Implementation**:

--- a/main/business/sales.cc
+++ b/main/business/sales.cc
@@ -811,6 +811,9 @@ int MergeQualifier(int &flag, int qualifier)
 		case QUALIFIER_CUT2:     flag = QUALIFIER_CUT2;      break;
         case QUALIFIER_CUT3:     flag = QUALIFIER_CUT3;      break;
         case QUALIFIER_CUT4:     flag = QUALIFIER_CUT4;      break;
+        case QUALIFIER_EASY:     flag = QUALIFIER_EASY;      break;
+        case QUALIFIER_ADD:      flag = QUALIFIER_ADD;       break;
+        case QUALIFIER_SENIORSHARE: flag = QUALIFIER_SENIORSHARE; break;
         }
 
         if (side)
@@ -849,6 +852,9 @@ int PrintItem(char* buffer, int qualifier, const char* item)
     else if ((qualifier & QUALIFIER_CUT2))      vt_safe_string::safe_format(pre, 64, "Cut/2 ");
     else if ((qualifier & QUALIFIER_CUT3))      vt_safe_string::safe_format(pre, 64, "Cut/3 ");
     else if ((qualifier & QUALIFIER_CUT4))      vt_safe_string::safe_format(pre, 64, "Cut/4 ");
+    else if ((qualifier & QUALIFIER_EASY))      vt_safe_string::safe_format(pre, 64, "Easy ");
+    else if ((qualifier & QUALIFIER_ADD))       vt_safe_string::safe_format(pre, 64, "Add ");
+    else if ((qualifier & QUALIFIER_SENIORSHARE)) vt_safe_string::safe_format(pre, 64, "Senior Share ");
     if ((qualifier & QUALIFIER_SUB))
         vt_safe_string::safe_format(buffer, STRLENGTH, "SUB: %s%s%s", pre, item, post);
     else

--- a/main/business/sales.hh
+++ b/main/business/sales.hh
@@ -87,6 +87,9 @@
 #define QUALIFIER_CUT2      (1<<18)
 #define QUALIFIER_CUT3      (1<<19)
 #define QUALIFIER_CUT4      (1<<20)
+#define QUALIFIER_EASY      (1<<21)
+#define QUALIFIER_ADD       (1<<22)
+#define QUALIFIER_SENIORSHARE (1<<23)
 
 // Item Definitions
 #define ITEM_NORMAL       0  // Regular menu item

--- a/main/ui/labels.cc
+++ b/main/ui/labels.cc
@@ -218,6 +218,7 @@ const genericChar* PageTypeName[] = {
 	"System Page", "Guest Check Page",
     "Kitchen 1 Page", "Kitchen 2 Page",
     "Bar 1 Page", "Bar 2 Page",
+    "Modifier Page with Keyboard", "Index with Tabs",
     NULL};
 
 int PageTypeValue[] = {
@@ -228,6 +229,7 @@ int PageTypeValue[] = {
 	PAGE_SYSTEM, PAGE_CHECKS,
     PAGE_KITCHEN_VID, PAGE_KITCHEN_VID2,
     PAGE_BAR1, PAGE_BAR2,
+    PAGE_MODIFIER_KEYBOARD, PAGE_INDEX_WITH_TABS,
     -1};
 
 const genericChar* PageType2Name[] = {
@@ -419,15 +421,18 @@ int CallOrderValue[] = {
 const genericChar* QualifierName[] = {
     "No", "Sub", "On Side", "Lite", "Only", "Extra", "Double", "Dry",
     "Plain", "Toast", "UnToast", "Crisp", "Soft", "Hard", "Grill",
-    "< Left", "Right >", "Whole", "Cut/2", "Cut/3", "Cut/4", NULL};
+    "< Left", "Right >", "Whole", "Cut/2", "Cut/3", "Cut/4", 
+    "Easy", "Add", "Senior Share", NULL};
 const genericChar* QualifierShortName[] = {
     "no", "sub", "side", "lite", "only", "extra", "double", "dry",
     "plain", "toast", "untoast", "crisp", "soft", "hard", "grill",
-    "< left", "right >", "whole", "cut/2", "cut/3", "cut/4", NULL};
+    "< left", "right >", "whole", "cut/2", "cut/3", "cut/4",
+    "easy", "add", "senior share", NULL};
 int QualifierValue[] = {
     QUALIFIER_NO, QUALIFIER_SUB, QUALIFIER_SIDE, QUALIFIER_LITE, QUALIFIER_ONLY, QUALIFIER_EXTRA, QUALIFIER_DOUBLE, QUALIFIER_DRY,
     QUALIFIER_PLAIN, QUALIFIER_TOASTED, QUALIFIER_UNTOASTED, QUALIFIER_CRISPY, QUALIFIER_SOFT, QUALIFIER_HARD, QUALIFIER_GRILLED,
-    QUALIFIER_LEFT, QUALIFIER_RIGHT, QUALIFIER_WHOLE, QUALIFIER_CUT2, QUALIFIER_CUT3, QUALIFIER_CUT4, -1};
+    QUALIFIER_LEFT, QUALIFIER_RIGHT, QUALIFIER_WHOLE, QUALIFIER_CUT2, QUALIFIER_CUT3, QUALIFIER_CUT4,
+    QUALIFIER_EASY, QUALIFIER_ADD, QUALIFIER_SENIORSHARE, -1};
 
 const genericChar* SwitchName[] = {
     "Seat Based Ordering", "Drawer Mode", "Use Passwords", "Credit For Sale",

--- a/term/term_view.hh
+++ b/term/term_view.hh
@@ -172,6 +172,8 @@ extern Translations MasterTranslations;
 #define PAGE_KITCHEN_VID2 14 // Secondary list of checks for cooks
 #define PAGE_BAR1         15
 #define PAGE_BAR2         16
+#define PAGE_MODIFIER_KEYBOARD 17  // Modifier page with keyboard (parent -96)
+#define PAGE_INDEX_WITH_TABS   18  // Index with tabs for quick navigation (parent -95)
 
 #define MAX_SCREEN_WIDTH 1920
 // #define MAX_SCREEN_WIDTH 1600

--- a/zone/zone.cc
+++ b/zone/zone.cc
@@ -560,6 +560,8 @@ int Page::Init(ZoneDB *zone_db)
     case PAGE_TABLE:     parent_id = PAGEID_TABLE; break;
     case PAGE_TABLE2:    parent_id = PAGEID_TABLE2; break;
     case PAGE_LIBRARY:   parent_id = 0; break;
+    case PAGE_MODIFIER_KEYBOARD: parent_id = -96; break;
+    case PAGE_INDEX_WITH_TABS:   parent_id = -95; break;
 	}
 
 	if (zone_db)

--- a/zone/zone.hh
+++ b/zone/zone.hh
@@ -32,6 +32,8 @@
 #define PAGE_KITCHEN_VID2 14  // Secondary list of checks for cooks
 #define PAGE_BAR1         15  // Bar mode page.
 #define PAGE_BAR2         16  // Second bar mode page.
+#define PAGE_MODIFIER_KEYBOARD 17  // Modifier page with keyboard (parent -96)
+#define PAGE_INDEX_WITH_TABS   18  // Index with tabs for quick navigation (parent -95)
 
 #define PAGE_ID_SETTLEMENT  -20  // Where the Settlement page is in the list.
 #define PAGE_ID_TABSETTLE   -85  // Where the Tab Settlement page is


### PR DESCRIPTION
- Added PAGE_MODIFIER_KEYBOARD (Type 17, Parent -96): Modifier page with keyboard and pre-positioned buttons for complex qualifier setups
- Added PAGE_INDEX_WITH_TABS (Type 18, Parent -95): Index page with inheritable tab navigation
- Added three new qualifiers: Easy, Add, and Senior Share
- Pages -95 & -96 are under development as parent templates
- Updated changelog with detailed feature descriptions and impact