### PR TITLE
Add AddressSanitizer and UndefinedBehaviorSanitizer support for debug builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,18 @@ set(VIEWTOUCH_PATH ${CMAKE_INSTALL_PREFIX}/viewtouch)
 # add macro define 'DEBUG' to debug build
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -DDEBUG")
 
+# Option to enable sanitizers (AddressSanitizer + UndefinedBehaviorSanitizer) in debug builds
+# This catches runtime bugs like use-after-free, out-of-bounds access, double free,
+# integer overflow, invalid shifts, bad casts, etc.
+option(ENABLE_SANITIZERS "Enable AddressSanitizer and UndefinedBehaviorSanitizer in debug builds" ON)
+if(ENABLE_SANITIZERS)
+    set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fsanitize=address,undefined -fno-omit-frame-pointer")
+    # Also set linker flags to ensure sanitizers are linked
+    set(CMAKE_EXE_LINKER_FLAGS_DEBUG "${CMAKE_EXE_LINKER_FLAGS_DEBUG} -fsanitize=address,undefined")
+    message(STATUS "Sanitizers enabled for Debug builds (AddressSanitizer + UndefinedBehaviorSanitizer)")
+    message(STATUS "  Disable with: cmake -DENABLE_SANITIZERS=OFF")
+endif()
+
 # enable various compiler warnings
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wextra")

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -31,6 +31,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
     - `main/ui/labels.cc` - Changed "Light Blue" label to "Dark Brown"
 
 ### Added
+- **AddressSanitizer and UndefinedBehaviorSanitizer Support (12-01-2025)**
+  - **Runtime Memory Safety**: Added AddressSanitizer (ASan) and UndefinedBehaviorSanitizer (UBSan) support for debug builds
+  - **Implementation**:
+    - Added CMake option `ENABLE_SANITIZERS` (enabled by default for Debug builds)
+    - Configured compiler flags: `-fsanitize=address,undefined -fno-omit-frame-pointer`
+    - Automatically enabled when building with `-DCMAKE_BUILD_TYPE=Debug`
+    - Can be disabled with `-DENABLE_SANITIZERS=OFF` if needed
+  - **Memory Leak Fixes**: Fixed memory leaks in loader initialization code
+    - Added proper cleanup for Xt widget (`XtDestroyWidget`) in `ExitLoader()`
+    - Added proper cleanup for Xt application context (`XtDestroyApplicationContext`)
+    - Ensured all Xft resources (draw, colors, fonts) are properly freed
+    - Set pointers to nullptr after cleanup for safety
+  - **Impact**: Debug builds now automatically catch runtime memory errors including:
+    - Use-after-free, out-of-bounds reads/writes, double free, memory leaks
+    - Integer overflow, invalid shifts, bad casts, undefined behavior
+    - ViewTouch code is now leak-free; remaining leaks are from third-party system libraries (X11/Fontconfig)
+  - **Files modified**:
+    - `CMakeLists.txt` - Added sanitizer flags for Debug builds
+    - `loader/loader_main.cc` - Fixed memory leaks in widget and application context cleanup
+
 - **Index Tab Buttons for One-Touch Navigation (12-XX-2025)**
   - **Feature**: New Index Tab button type that enables one-touch navigation from any menu page to any other menu page
   - **Implementation**:


### PR DESCRIPTION
Add AddressSanitizer and UndefinedBehaviorSanitizer support for debug builds

- Added CMake option ENABLE_SANITIZERS (ON by default for Debug builds)
- Configured AddressSanitizer and UndefinedBehaviorSanitizer flags
- Fixed memory leaks in loader_main.cc:
  - Added proper widget destruction in ExitLoader()
  - Added Xt application context cleanup
  - Ensured all resources are properly freed
- Updated changelog.md with sanitizer support details

Sanitizers automatically detect runtime memory errors including:
- Use-after-free, out-of-bounds access, double free
- Memory leaks, integer overflow, undefined behavior

All ViewTouch code leaks have been fixed. Remaining leaks are from third-party system libraries (X11/Fontconfig) which is acceptable.