### PR TITLE
Fix buffer initialization in memory mapping parser

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -71,7 +71,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
   - **Impact**: When ViewTouch crashes, detailed crash reports are automatically generated and saved, making it much easier to diagnose and fix issues. Reports now include comprehensive crash analysis explaining WHY the crash occurred, memory mapping information, recent error context, and detailed hardware/OS information to help identify environment-specific problems.
   - **Files modified**:
     - `src/core/crash_report.hh` - Crash reporting interface with siginfo support
-    - `src/core/crash_report.cc` - Enhanced crash report generation with detailed signal analysis, memory mapping, error log integration, and crash analysis explanations
+    - `src/core/crash_report.cc` - Enhanced crash report generation with detailed signal analysis, memory mapping, error log integration, and crash analysis explanations. Fixed buffer initialization issue in memory mapping parser to prevent uninitialized memory access.
     - `main/data/manager.cc` - Integrated crash reporting into signal handlers and added test crash command
     - `CMakeLists.txt` - Added crash_report files to build and created crashreports directory during installation
 

--- a/src/core/crash_report.cc
+++ b/src/core/crash_report.cc
@@ -457,15 +457,24 @@ namespace vt_crash {
             
             while (fgets(line, sizeof(line), maps)) {
                 uintptr_t start, end;
-                char perms[5], offset[17], dev[6], inode[17], path[256];
+                char perms[5] = "";
+                char offset[17] = "";
+                char dev[6] = "";
+                char inode[17] = "";
+                char path[256] = "";
                 
-                if (sscanf(line, "%lx-%lx %4s %16s %5s %16s %255s", 
-                          &start, &end, perms, offset, dev, inode, path) >= 3) {
+                // Parse /proc/self/maps format: start-end perms offset dev inode [path]
+                // We need at least 6 fields (start, end, perms, offset, dev, inode)
+                // Path is optional (7th field) - anonymous mappings don't have paths
+                int fields_parsed = sscanf(line, "%lx-%lx %4s %16s %5s %16s %255s", 
+                                          &start, &end, perms, offset, dev, inode, path);
+                
+                if (fields_parsed >= 6) {
                     if (target_addr >= start && target_addr < end) {
                         oss << "  Memory Region: 0x" << std::hex << start << "-0x" << end << std::dec << "\n";
                         oss << "  Permissions: " << perms << "\n";
                         oss << "  Offset: " << offset << "\n";
-                        if (path[0] != '\0') {
+                        if (fields_parsed >= 7 && path[0] != '\0') {
                             oss << "  File/Path: " << path << "\n";
                         } else {
                             oss << "  Type: Anonymous mapping\n";
@@ -838,4 +847,3 @@ namespace vt_crash {
     }
 
 } // namespace vt_crash
-


### PR DESCRIPTION
- Initialize all buffers to empty strings before sscanf to prevent uninitialized memory access
- Require at least 6 fields parsed (start, end, perms, offset, dev, inode) before using those fields
- Only access path field if 7 fields were successfully parsed
- Prevents potential buffer overflows and undefined behavior when parsing /proc/self/maps lines with incomplete data