### PR TITLE
Add kitchen/bar timer toggle setting in Settings page

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -79,6 +79,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
     - `main/ui/labels.cc` - Changed "Light Blue" label to "Dark Brown"
 
 ### Added
+- **Kitchen/Bar Timer Toggle Setting (12-03-2025)**
+  - **Feature**: Added ability to enable/disable kitchen/bar timers in Settings page under Kitchen section
+  - **Implementation**:
+    - Added `enable_kitchen_bar_timers` setting (default: enabled/On) to control kitchen/bar timer functionality
+    - Added "Kitchen/Bar Timers" On/Off toggle in Kitchen section of Settings page
+    - Updated all timer-related code to check this setting before setting `chef_time` or displaying elapsed time
+    - When disabled, timers will not start and elapsed time will not be displayed on kitchen video displays
+  - **Impact**: Users can now control whether kitchen/bar timers are active, providing flexibility for different operational needs. Timers default to enabled for backward compatibility.
+  - **Files modified**:
+    - `main/data/settings.hh` - Added `enable_kitchen_bar_timers` field, updated SETTINGS_VERSION to 106
+    - `main/data/settings.cc` - Added initialization, read/write logic for new setting
+    - `zone/settings_zone.cc` - Added UI control in Kitchen section, updated LoadRecord/SaveRecord
+    - `main/business/check.cc` - Updated FinalizeOrders(), Close(), PrintWorkOrder(), MakeReport() to check setting
+    - `zone/report_zone.cc` - Updated GetDisplayCheck() to check setting
+
 - **Automatic Crash Report Generation (12-02-2025)**
   - **Feature**: Automatic GDB-like crash report generation when ViewTouch crashes
   - **Implementation**:

--- a/main/data/settings.cc
+++ b/main/data/settings.cc
@@ -1421,6 +1421,7 @@ Settings::Settings()
     kv_warn_color         = COLOR_YELLOW;
     kv_alert_color        = COLOR_RED;
     kv_flash_color        = COLOR_RED;
+    enable_kitchen_bar_timers = 1;  // Default to enabled
 
     // Media
     last_discount_id   = 0;
@@ -2197,6 +2198,9 @@ int Settings::Load(const char* file)
         df.Read(kv_alert_color);
         df.Read(kv_flash_color);
     }
+    if (version >= 106) {
+        df.Read(enable_kitchen_bar_timers);
+    }
 
     if (store == STORE_SUNWEST)
         media_balanced |=
@@ -2574,6 +2578,7 @@ int Settings::Save()
     df.Write(kv_warn_color);
     df.Write(kv_alert_color);
     df.Write(kv_flash_color);
+    df.Write(enable_kitchen_bar_timers);
 
     df.Close();
 

--- a/main/data/settings.hh
+++ b/main/data/settings.hh
@@ -30,7 +30,7 @@
 // NOTE:  WHEN UPDATING SETTINGS DO NOT FORGET that you may also
 // need to update archive.hh and archive.cc for settings which
 // should be maintained historically.
-constexpr int SETTINGS_VERSION = 105;  // READ ABOVE
+constexpr int SETTINGS_VERSION = 106;  // READ ABOVE
 
 
 /**** Definitions & Data ****/
@@ -715,6 +715,7 @@ public:
     int      kv_warn_color;         // color for warning state (default yellow)
     int      kv_alert_color;        // color for alert state (default red)
     int      kv_flash_color;        // color for flashing state (default red)
+    int      enable_kitchen_bar_timers;  // enable/disable kitchen/bar timers (default on)
 
     // Job/Security/Overtime Settings
     int job_active[MAX_JOBS];

--- a/zone/report_zone.cc
+++ b/zone/report_zone.cc
@@ -578,7 +578,8 @@ Check *ReportZone::GetDisplayCheck(Terminal *term)
     if (disp_check)
     {
         disp_check->checknum = check_disp_num;
-        if (disp_check->check_state == 0)
+        Settings *settings = term->GetSettings();
+        if (disp_check->check_state == 0 && settings->enable_kitchen_bar_timers)
         {
             disp_check->chef_time.Set();
             disp_check->check_state = ORDER_SENT;

--- a/zone/settings_zone.cc
+++ b/zone/settings_zone.cc
@@ -611,6 +611,8 @@ SettingsZone::SettingsZone()
     kitchen_start = FieldListEnd();  // Point to the label field
     AddNewLine();
     LeftAlign();
+    AddListField("Kitchen/Bar Timers", YesNoName, YesNoValue);
+    AddNewLine();
     AddTextField("Warning Time (minutes)", 5); SetFlag(FF_ONLYDIGITS);
     AddTextField("Alert Time (minutes)", 5); SetFlag(FF_ONLYDIGITS);
     AddTextField("Flash Time (minutes)", 5); SetFlag(FF_ONLYDIGITS);
@@ -911,6 +913,7 @@ int SettingsZone::LoadRecord(Terminal *term, int /*record*/)
     case 7:  // Kitchen Video Order Alert Settings
         f = kitchen_start;
         if (f) f = f->next;  // skip past label
+        if (f) { f->Set(settings->enable_kitchen_bar_timers); f = f->next; }
         if (f) { f->Set(settings->kv_order_warn_time); f = f->next; }
         if (f) { f->Set(settings->kv_order_alert_time); f = f->next; }
         if (f) { f->Set(settings->kv_order_flash_time); f = f->next; }
@@ -1008,6 +1011,7 @@ int SettingsZone::SaveRecord(Terminal *term, int record, int write_file)
     case 7:  // Kitchen Video Order Alert Settings
         f = kitchen_start;
         if (f) f = f->next;  // skip past label
+        if (f) { f->Get(settings->enable_kitchen_bar_timers); f = f->next; }
         if (f) { f->Get(settings->kv_order_warn_time); f = f->next; }
         if (f) { f->Get(settings->kv_order_alert_time); f = f->next; }
         if (f) { f->Get(settings->kv_order_flash_time); f = f->next; }


### PR DESCRIPTION
- Added enable_kitchen_bar_timers setting (default: enabled) to control timer functionality
- Added 'Kitchen/Bar Timers' On/Off toggle in Kitchen section of Settings page
- Updated all timer-related code to check this setting before setting chef_time or displaying elapsed time
- When disabled, timers will not start and elapsed time will not be displayed
- Updated SETTINGS_VERSION to 106 for new setting persistence