### PR TITLE
Remove page variants, Sunwest support, and kitchen timer toggle; enhance edit toolbar

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,71 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+### Removed
+- **Page Variant System Removal (12-03-2025)**
+  - **Removal**: Completely removed page variant functionality from the system
+  - **Implementation**:
+    - Removed `page_variant` field from `TermInfo` and `Terminal` classes
+    - Removed "Default Page Variant" UI field from hardware configuration
+    - Removed `FindByTerminalWithVariant()` function and replaced all calls with `FindByTerminal()`
+    - Removed page variant read/write from settings file I/O
+    - Removed `PageVariantName` and `PageVariantValue` label definitions
+    - Simplified terminal initialization and page navigation code
+  - **Impact**: System now uses simpler, direct terminal-to-page mapping without variant configuration. All terminals use their default page types.
+  - **Files modified**:
+    - `main/data/settings.hh` - Removed page_variant field from TermInfo
+    - `main/data/settings.cc` - Removed page_variant initialization, read/write
+    - `main/hardware/terminal.hh` - Removed page_variant field from Terminal
+    - `main/hardware/terminal.cc` - Removed all page_variant logic, simplified page finding
+    - `zone/hardware_zone.cc` - Removed page variant UI field
+    - `zone/zone.cc` - Removed FindByTerminalWithVariant() function
+    - `zone/zone.hh` - Removed FindByTerminalWithVariant() declaration
+    - `main/ui/labels.cc` - Removed PageVariantName/PageVariantValue arrays
+    - `main/ui/labels.hh` - Removed PageVariantName/PageVariantValue declarations
+
+- **Company Sunwest Support Removal (12-03-2025)**
+  - **Removal**: Removed all Sunwest-specific code and company option
+  - **Implementation**:
+    - Removed `STORE_SUNWEST` from company/store selection options
+    - Removed Sunwest-specific media balance code
+    - Removed Sunwest-specific navigation hacks in terminal and order zones
+    - Removed Sunwest-specific entree count logic
+  - **Impact**: System no longer includes Sunwest-specific functionality. All stores use standard behavior.
+  - **Files modified**:
+    - `main/data/settings.hh` - Removed STORE_SUNWEST definition
+    - `main/data/settings.cc` - Removed STORE_SUNWEST from StoreName/StoreValue, removed Sunwest media balance code
+    - `main/hardware/terminal.cc` - Removed Sunwest navigation hacks
+    - `zone/order_zone.cc` - Removed Sunwest-specific entree logic
+    - `main/business/check.cc` - Removed Sunwest comment
+
+- **Kitchen/Bar Timer Toggle Removal (12-03-2025)**
+  - **Removal**: Removed user-configurable toggle for kitchen/bar timers
+  - **Implementation**:
+    - Removed "Kitchen/Bar Timers" On/Off toggle from Kitchen section in Settings
+    - Timer functionality remains enabled by default (setting still exists but is not user-configurable)
+  - **Impact**: Kitchen/bar timers are always enabled. Users can no longer disable this feature.
+  - **Files modified**:
+    - `zone/settings_zone.cc` - Removed timer toggle UI field and LoadRecord/SaveRecord code
+
+### Changed
+- **Edit Toolbar Size Enhancement (12-03-2025)**
+  - **UI Enhancement**: Made edit toolbar and buttons wider for better usability
+  - **Implementation**:
+    - Increased toolbar width from 120 to 180 pixels (50% wider)
+    - Increased button width from 60 to 90 pixels (50% wider)
+    - Adjusted button positions to accommodate wider buttons
+  - **Impact**: Edit toolbar is now more spacious and easier to use, with larger buttons that are easier to click.
+  - **Files modified**:
+    - `main/hardware/terminal.cc` - Updated toolbar and button dimensions
+
+- **Self Order Terminal Configuration Simplification (12-03-2025)**
+  - **UI Simplification**: Removed unnecessary "Default Page Variant" setting for Self Order terminals
+  - **Implementation**:
+    - Hidden page variant field when terminal type is Self Order (before complete removal)
+  - **Impact**: Self Order terminal configuration is now simpler with fewer unnecessary options.
+  - **Files modified**:
+    - `zone/hardware_zone.cc` - Conditionally hide page variant field for Self Order terminals
+
 ### Fixed
 - **Security and Code Quality Fixes from clang-tidy Analysis (12-02-2025)**
   - **Security Fixes**: Replaced insecure `strcat` calls with safe `vt_safe_string::safe_concat` functions

--- a/main/business/check.cc
+++ b/main/business/check.cc
@@ -2596,7 +2596,6 @@ int Check::EntreeCount(int seat)
 {
     FnTrace("Check::EntreeCount()");
     int count = 0;
-    // FIX - entree count modified for SunWest
 
     for (SubCheck *sc = SubList(); sc != nullptr; sc = sc->next)
         for (Order *order = sc->OrderList(); order != nullptr; order = order->next)

--- a/main/data/settings.cc
+++ b/main/data/settings.cc
@@ -61,9 +61,9 @@ namespace fs = std::filesystem;
  ********************************************************************/
 
 const char* StoreName[] = {
-    GlobalTranslate("Other"), GlobalTranslate("SunWest"), NULL};
+    GlobalTranslate("Other"), NULL};
 int StoreValue[] = {
-    STORE_OTHER, STORE_SUNWEST, -1};
+    STORE_OTHER, -1};
 
 const char* PayPeriodName[] = {
     GlobalTranslate("Weekly"), GlobalTranslate("2 Weeks"), GlobalTranslate("4 Weeks"), GlobalTranslate("Semi Monthly"), GlobalTranslate("Semi Monthly 11/26"), GlobalTranslate("Monthly"), NULL};
@@ -903,7 +903,6 @@ TermInfo::TermInfo()
     isserver      = 0;
     print_workorder = 1;
     workorder_heading = 0;
-    page_variant = 0;        // Default to Page -1
 
     for (int i=0; i<4; i++)
     	tax_inclusive[i] = -1;
@@ -950,8 +949,6 @@ int TermInfo::Read(InputDataFile &df, int version)
     	error += df.Read(print_workorder);
     if (version >= 93)
     	error += df.Read(workorder_heading);
-    if (version >= 95)
-    	error += df.Read(page_variant);
     if (version >= 94)
     {
 	for (int i=0; i<4; i++)
@@ -995,7 +992,6 @@ int TermInfo::Write(OutputDataFile &df, int version)
     error += df.Write(cc_debit_termid);
     error += df.Write(print_workorder);
     error += df.Write(workorder_heading);
-    error += df.Write(page_variant);
     for (int i=0; i<4; i++)
     	error += df.Write(tax_inclusive[i]);
 
@@ -1035,7 +1031,6 @@ int TermInfo::OpenTerm(Control *control_db, int update)
     term->cc_debit_termid.Set(cc_debit_termid);
     term->print_workorder = print_workorder;
     term->workorder_heading = workorder_heading;
-    term->page_variant = page_variant;
     for (int i=0; i<4; i++)
     	term->tax_inclusive[i] = tax_inclusive[i];
 
@@ -2202,10 +2197,6 @@ int Settings::Load(const char* file)
         df.Read(enable_kitchen_bar_timers);
     }
 
-    if (store == STORE_SUNWEST)
-        media_balanced |=
-            (1<<TENDER_COMP)|(1<<TENDER_DISCOUNT)|(1<<TENDER_EMPLOYEE_MEAL)|
-            (1<<TENDER_PAID_TIP);
 
     if (authorize_method == CCAUTH_MAINSTREET)
         card_types &= ~CARD_TYPE_DEBIT;

--- a/main/data/settings.hh
+++ b/main/data/settings.hh
@@ -110,7 +110,6 @@ constexpr int SETTINGS_VERSION = 106;  // READ ABOVE
 
 // Store/Company
 #define STORE_OTHER   0  // Other
-#define STORE_SUNWEST 1  // Jerry's, Keuken Dutch
 
 // Tender Flags
 #define TF_IS_PERCENT      1    // amount calculated by percent
@@ -488,7 +487,6 @@ public:
     int workorder_heading;	// 0=standard, 1=simple
     Str cc_credit_termid;
     Str cc_debit_termid;
-    int page_variant;        // 0=Page -1, 1=Page -2
 
     // Tax settings override
     //  0=prices don't include tax

--- a/main/hardware/terminal.hh
+++ b/main/hardware/terminal.hh
@@ -343,7 +343,6 @@ public:
     int       mouse_x;        // current mouse position
     int       mouse_y;
     int       allow_blanking;
-    int       page_variant;   // 0=Page -1, 1=Page -2
 
     // POS Data
     Archive      *archive;          // Current archive being viewed

--- a/main/ui/labels.cc
+++ b/main/ui/labels.cc
@@ -550,9 +550,7 @@ const char* NoYesName[] = {"No", "Yes", NULL};
 int   NoYesValue[] = {0, 1, -1};
 
 const char* NoYesGlobalName[] = {"No", "Yes", "Global", NULL};
-const char* PageVariantName[] = {"Page -1", "Page -2", NULL};
 int   NoYesGlobalValue[] = {0, 1, -1, -1};
-int   PageVariantValue[] = {0, 1, -1};
 
 const char* SplitCheckName[]  = {"Item", "Seat", NULL};
 int   SplitCheckValue[] = {SPLIT_CHECK_ITEM, SPLIT_CHECK_SEAT, -1};

--- a/main/ui/labels.hh
+++ b/main/ui/labels.hh
@@ -129,9 +129,7 @@ extern int   YesNoValue[];
 extern const char* NoYesName[];
 extern int   NoYesValue[];
 extern const char* NoYesGlobalName[];
-extern const char* PageVariantName[];
 extern int   NoYesGlobalValue[];
-extern int   PageVariantValue[];
 
 extern const char* SplitCheckName[];
 extern int   SplitCheckValue[];

--- a/zone/hardware_zone.cc
+++ b/zone/hardware_zone.cc
@@ -91,8 +91,6 @@ HardwareZone::HardwareZone()
     AddListField("Do Room prices include tax?", NoYesGlobalName, NoYesGlobalValue);
     AddListField("Do Merchandise prices include tax?", NoYesGlobalName, NoYesGlobalValue);
     
-    AddNewLine();
-    AddListField("Default Page Variant", PageVariantName, PageVariantValue);
 
     Center();
     AddNewLine();
@@ -321,7 +319,6 @@ int HardwareZone::LoadRecord(Terminal *term, int record)
     	thisForm->Set(ti->tax_inclusive[2]); thisForm->active = 1; thisForm = thisForm->next;
     	thisForm->Set(ti->tax_inclusive[1]); thisForm->active = 1; thisForm = thisForm->next;
     	thisForm->Set(ti->tax_inclusive[3]); thisForm->active = 1; thisForm = thisForm->next;
-    	thisForm->Set(ti->page_variant); thisForm->active = 1; thisForm = thisForm->next;
 
         if (MasterSystem->settings.authorize_method == CCAUTH_CREDITCHEQ)
         {
@@ -361,13 +358,7 @@ int HardwareZone::SaveRecord(Terminal *term, int record, int write_file)
             Str tmp;
             field = term_start;
             field->Get(ti->name); field = field->next;
-            int old_type = ti->type;
             field->Get(ti->type); field = field->next;
-            // Automatically set page_variant to 1 (Page -2) when Self Order Mode is selected
-            if (ti->type == TERMINAL_SELFORDER && old_type != TERMINAL_SELFORDER)
-            {
-                ti->page_variant = 1;  // Page -2 for Self Order Mode
-            }
             field->Get(ti->sortorder); field = field->next;
             field->Get(ti->workorder_heading); field = field->next;
             field->Get(ti->print_workorder); field = field->next;
@@ -389,7 +380,6 @@ int HardwareZone::SaveRecord(Terminal *term, int record, int write_file)
 			field->Get(ti->tax_inclusive[2]); field = field->next;
 			field->Get(ti->tax_inclusive[1]); field = field->next;
 			field->Get(ti->tax_inclusive[3]); field = field->next;
-			field->Get(ti->page_variant); field = field->next;
 
             if (MasterSystem->settings.authorize_method == CCAUTH_CREDITCHEQ)
             {

--- a/zone/order_zone.cc
+++ b/zone/order_zone.cc
@@ -925,13 +925,7 @@ int OrderEntryZone::ShowSeat(Terminal *t, int seat)
     t->order = NULL;
     t->Update(UPDATE_ORDERS, NULL);
 
-    if (s->store == STORE_SUNWEST)
-    {
-        if (c->EntreeCount(t->seat) <= 0 || c->IsTakeOut())
-            t->Jump(JUMP_NORMAL, 200);
-        else
-            t->Jump(JUMP_NORMAL, 206);
-    }
+    // Removed SunWest-specific code - no longer needed
     return 0;
 }
 
@@ -1342,9 +1336,10 @@ SignalResult OrderAddZone::Touch(Terminal *term, int /*tx*/, int /*ty*/)
     {
         return SIGNAL_IGNORED;
     }
-    else if (s->store == STORE_SUNWEST && order->IsEntree() && !(c->IsTakeOut() || c->IsFastFood()))
+    // Removed SunWest-specific code
+    else if (0 && order->IsEntree() && !(c->IsTakeOut() || c->IsFastFood()))
     {
-        // Can't increase 'entree' order (for SunWest)
+        // Can't increase 'entree' order
         return SIGNAL_IGNORED;
     }
     else if (order->status & ORDER_FINAL)

--- a/zone/settings_zone.cc
+++ b/zone/settings_zone.cc
@@ -611,8 +611,6 @@ SettingsZone::SettingsZone()
     kitchen_start = FieldListEnd();  // Point to the label field
     AddNewLine();
     LeftAlign();
-    AddListField("Kitchen/Bar Timers", YesNoName, YesNoValue);
-    AddNewLine();
     AddTextField("Warning Time (minutes)", 5); SetFlag(FF_ONLYDIGITS);
     AddTextField("Alert Time (minutes)", 5); SetFlag(FF_ONLYDIGITS);
     AddTextField("Flash Time (minutes)", 5); SetFlag(FF_ONLYDIGITS);
@@ -913,7 +911,6 @@ int SettingsZone::LoadRecord(Terminal *term, int /*record*/)
     case 7:  // Kitchen Video Order Alert Settings
         f = kitchen_start;
         if (f) f = f->next;  // skip past label
-        if (f) { f->Set(settings->enable_kitchen_bar_timers); f = f->next; }
         if (f) { f->Set(settings->kv_order_warn_time); f = f->next; }
         if (f) { f->Set(settings->kv_order_alert_time); f = f->next; }
         if (f) { f->Set(settings->kv_order_flash_time); f = f->next; }
@@ -1011,7 +1008,6 @@ int SettingsZone::SaveRecord(Terminal *term, int record, int write_file)
     case 7:  // Kitchen Video Order Alert Settings
         f = kitchen_start;
         if (f) f = f->next;  // skip past label
-        if (f) { f->Get(settings->enable_kitchen_bar_timers); f = f->next; }
         if (f) { f->Get(settings->kv_order_warn_time); f = f->next; }
         if (f) { f->Get(settings->kv_order_alert_time); f = f->next; }
         if (f) { f->Get(settings->kv_order_flash_time); f = f->next; }

--- a/zone/zone.cc
+++ b/zone/zone.cc
@@ -1743,35 +1743,6 @@ Page *ZoneDB::FindByTerminal(int term_type, int period, int max_size)
         return NULL;
 }
 
-Page *ZoneDB::FindByTerminalWithVariant(int term_type, int page_variant, int period, int max_size)
-{
-    FnTrace("ZoneDB::FindByTerminalWithVariant()");
-    int type = 0;
-    switch (term_type)
-    {
-        case TERMINAL_BAR: 
-        case TERMINAL_BAR2: 
-            type = (page_variant == 1) ? PAGE_BAR2 : PAGE_BAR1; 
-            break;
-        case TERMINAL_KITCHEN_VIDEO: 
-        case TERMINAL_KITCHEN_VIDEO2: 
-            type = (page_variant == 1) ? PAGE_KITCHEN_VID2 : PAGE_KITCHEN_VID; 
-            break;
-        case TERMINAL_NORMAL:
-        case TERMINAL_FASTFOOD:
-            // For normal terminals, choose between PAGE_TABLE and page -2
-            if (page_variant == 1)
-                return FindByID(-2, max_size); // Page -2
-            else
-                type = PAGE_TABLE; // Page -1
-            break;
-    }
-    if (type != 0)
-        return FindByType(type, period, max_size);
-    else
-        return NULL;
-}
-
 Page *ZoneDB::FirstTablePage(int max_size)
 {
     FnTrace("ZoneDB::FirstTablePage()");

--- a/zone/zone.hh
+++ b/zone/zone.hh
@@ -380,7 +380,6 @@ public:
     Page *FindByID(int id, int max_size = SIZE_1280x1024);
     Page *FindByType(int type, int period = -1, int max_size = SIZE_1280x1024);
     Page *FindByTerminal(int term_type, int period = -1, int max_size = SIZE_1280x1024);
-    Page *FindByTerminalWithVariant(int term_type, int page_variant, int period = -1, int max_size = SIZE_1280x1024);
     Page *FirstTablePage(int max_size = SIZE_1280x1024);
 
     int References(Page *p, int *list, int max, int &count);


### PR DESCRIPTION
- Removed entire page variant system (fields, UI, functions, labels)
- Removed all Sunwest-specific code and company option
- Removed kitchen/bar timer toggle (always enabled now)
- Made edit toolbar and buttons 50% wider for better usability
- Simplified Self Order terminal configuration