### PR TITLE
Fix dialog menu overflow and shutdown cleanup

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -72,6 +72,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
     - `zone/hardware_zone.cc` - Conditionally hide page variant field for Self Order terminals
 
 ### Fixed
+- **Dialog menu buffer overflow and shutdown stability (12-05-2025)**
+  - **Issue**: Dialog menus used `CompareList(int)` with a non-sentinel list, overrunning the value buffer and crashing in `DialogMenu::Set`. Shutdown could segfault removing Xt timeouts after the app context was destroyed. Item name array used `calloc` but was freed with `delete[]`, triggering allocator mismatches under ASan.
+  - **Fix**: Bounded iteration over dialog value lists, guarded `XtRemoveTimeOut` when the Xt context is gone, and aligned ItemDB name array allocation/deallocation to `new[]`/`delete[]`.
+  - **Files modified**:
+    - `term/term_dialog.cc`
+    - `term/term_view.cc`
+    - `main/business/sales.cc`
 - **Event loop stall logging (12-04-2025)**
   - **Issue**: ViewTouch could freeze/lock up after long runtimes with no clear trace.
   - **Fix**: Added watchdog logging in `UpdateSystemCB` to report when the main loop stalls (>3s gap) to aid diagnosis of future lockups.

--- a/main/business/sales.cc
+++ b/main/business/sales.cc
@@ -700,14 +700,14 @@ int ItemDB::BuildNameArray()
     FnTrace("ItemDB::BuildNameArray()");
     if (name_array != NULL)
     {
-	free(name_array);
+        delete [] name_array;
         name_array = NULL;
         array_size = 0;
     }
 
     // Build search array
     array_size = ItemCount();
-    name_array = (SalesItem **)calloc(sizeof(SalesItem *), (array_size + 1));
+    name_array = new(std::nothrow) SalesItem*[array_size + 1](); // zero-initialized
     if (name_array == NULL)
     {
         array_size = 0;

--- a/term/term_dialog.cc
+++ b/term/term_dialog.cc
@@ -366,13 +366,18 @@ int DialogMenu::Show(int flag)
 
 int DialogMenu::Set(int value)
 {
-    if (no_change_widget && (value == no_change_value))
+    if (no_change_widget && (value == no_change_value)) {
         XtVaSetValues(option, XmNmenuHistory, no_change_widget, NULL);
-    else
-    {
-        int idx = CompareList(value, value_list.data(), -1);
-        if (idx >= 0 && idx < static_cast<int>(choices.size()))
-            XtVaSetValues(option, XmNmenuHistory, choices[static_cast<size_t>(idx)], NULL);
+        return 0;
+    }
+
+    // value_list is sized exactly to the number of choices (no sentinel),
+    // so walk it directly to avoid overrunning the buffer.
+    for (size_t i = 0; i < value_list.size(); ++i) {
+        if (value == value_list[i] && i < choices.size()) {
+            XtVaSetValues(option, XmNmenuHistory, choices[i], NULL);
+            break;
+        }
     }
     return 0;
 }

--- a/term/term_view.cc
+++ b/term/term_view.cc
@@ -3723,9 +3723,15 @@ int StopUpdates()
 {
     FnTrace("StopUpdates()");
 
-    if (UpdateTimerID)
+    // XtRemoveTimeOut can crash if the application context has already been
+    // destroyed. Guard against null context and wrap removal in a try block.
+    if (UpdateTimerID && App)
     {
-        XtRemoveTimeOut(UpdateTimerID);
+        try {
+            XtRemoveTimeOut(UpdateTimerID);
+        } catch (...) {
+            fprintf(stderr, "StopUpdates: Exception during XtRemoveTimeOut, continuing\n");
+        }
         UpdateTimerID = 0;
     }
     return 0;


### PR DESCRIPTION
- **Dialog menu buffer overflow and shutdown stability (12-05-2025)**
  - **Issue**: Dialog menus used `CompareList(int)` with a non-sentinel list, overrunning the value buffer and crashing in `DialogMenu::Set`. Shutdown could segfault removing Xt timeouts after the app context was destroyed. Item name array used `calloc` but was freed with `delete[]`, triggering allocator mismatches under ASan.
  - **Fix**: Bounded iteration over dialog value lists, guarded `XtRemoveTimeOut` when the Xt context is gone, and aligned ItemDB name array allocation/deallocation to `new[]`/`delete[]`.
  - **Files modified**:
    - `term/term_dialog.cc`
    - `term/term_view.cc`
    - `main/business/sales.cc`