### PR TITLE
Document buffer safety and SMTP child reaping fixes

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -85,6 +85,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
     - `zone/hardware_zone.cc` - Conditionally hide page variant field for Self Order terminals
 
 ### Fixed
+- **SMTP child reaping and safer string handling (12-09-2025)**
+  - Ensured SMTP helper processes are waited on to prevent zombie accumulation and pulled in the proper waitpid header.
+  - Bounded `Terminal::ReplaceSymbols` output to the stack buffer size while preserving null termination to avoid overruns when expanding placeholders.
+  - `POFile::Add` now returns a success flag after inserting entries so callers can detect successful additions.
+  - **Files modified**:
+    - `src/network/socket.cc`
+    - `main/hardware/terminal.cc`
+    - `main/data/locale.cc`
 - **Safety and correctness fixes (12-09-2025)**
   - Hardened page reference rendering to prevent buffer overruns when many references are listed.
   - Restored accurate metric/imperial conversions for inventory units (grams/ml ↔ ounces) so changing units preserves amounts.

--- a/main/data/locale.cc
+++ b/main/data/locale.cc
@@ -486,6 +486,7 @@ int POFile::Add(const char* newkey, const char* newvalue)
             entry_tail->next = entry;
             entry_tail = entry;
         }
+        retval = 1; // signal success to callers
     }
 
     return retval;

--- a/main/hardware/terminal.cc
+++ b/main/hardware/terminal.cc
@@ -3312,12 +3312,14 @@ const genericChar* Terminal::ReplaceSymbols(const genericChar* str)
 	if (edit || str == nullptr)
 		return (genericChar*)str;		//TODO: what to do in edit mode?  This is impossible to do correctly.  Can cause a stack overlflow
 
+	const size_t buffer_capacity = sizeof(buffer) / sizeof(genericChar);
 	genericChar* rawBuffer = buffer;
+	genericChar* bufferEnd = buffer + buffer_capacity - 1; // reserve space for null
 	if (str)
 	{
 		genericChar tmp[STRLENGTH];
         const genericChar* thisStr = str;
-		while (*thisStr)
+		while (*thisStr && rawBuffer < bufferEnd)
 		{
 			if (*thisStr != '{')
             {
@@ -3329,7 +3331,7 @@ const genericChar* Terminal::ReplaceSymbols(const genericChar* str)
 				genericChar* t = tmp;
 
 				// fill tmp with chars from str until '}'
-				while (*thisStr && *thisStr != '}')
+				while (*thisStr && *thisStr != '}' && t < tmp + STRLENGTH - 1)
 					*t++ = *thisStr++;
 
 				// terminate the genericChar array
@@ -3384,7 +3386,7 @@ const genericChar* Terminal::ReplaceSymbols(const genericChar* str)
 
 				t = tmp;
 
-				while (*t)
+				while (*t && rawBuffer < bufferEnd)
 					*rawBuffer++ = *t++;
 
 				if (*thisStr)

--- a/src/network/socket.cc
+++ b/src/network/socket.cc
@@ -30,6 +30,7 @@
 #include <unistd.h>
 #include <csignal>
 #include <netdb.h>
+#include <sys/wait.h>
 #include <utility>
 
 #ifdef DMALLOC
@@ -725,6 +726,14 @@ int SMTP(int fd, Email *email)
             exit(1);
         }
         exit(0);
+    }
+    else if (pid > 0)
+    {
+        int status = 0;
+        // Ensure the child is reaped to avoid zombies; retry if interrupted.
+        while (waitpid(pid, &status, 0) == -1 && errno == EINTR)
+        {
+        }
     }
 
     return retval;


### PR DESCRIPTION
- **SMTP child reaping and safer string handling (12-09-2025)**
  - Ensured SMTP helper processes are waited on to prevent zombie accumulation and pulled in the proper waitpid header.
  - Bounded `Terminal::ReplaceSymbols` output to the stack buffer size while preserving null termination to avoid overruns when expanding placeholders.
  - `POFile::Add` now returns a success flag after inserting entries so callers can detect successful additions.
  - **Files modified**:
    - `src/network/socket.cc`
    - `main/hardware/terminal.cc`
    - `main/data/locale.cc`