### PR TITLE
Make add comment keyboard almost full screen width

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,8 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ## [Unreleased]
 
 ### Fixed
-- **Add comment keyboard enlarged (12-09-2025)**
-  - Increased OrderCommentDialog keyboard button height from 90 to 110 pixels and dialog height from 780 to 850 pixels for better usability.
+- **Add comment keyboard enlarged and widened (12-09-2025)**
+  - Increased OrderCommentDialog width from 950 to 1800 pixels (almost full screen on 1920x1080 displays), button height from 90 to 110 pixels, and dialog height from 780 to 850 pixels for maximum usability.
   - **Files modified**:
     - `zone/dialog_zone.cc`
   - Replaced unsafe `strncpy` + manual null termination patterns with `vt_safe_string::safe_copy` throughout the codebase.

--- a/zone/dialog_zone.cc
+++ b/zone/dialog_zone.cc
@@ -3442,6 +3442,8 @@ OrderCommentDialog::OrderCommentDialog(const char* msg, const char* retmsg, int 
     : GetTextDialog(msg, retmsg, mlen)
 {
     FnTrace("OrderCommentDialog::OrderCommentDialog(const char* )");
+    // Make dialog almost full screen width for 1920x1080 displays
+    w = 1800;  // Increased from 950 to fit almost all screen width
     // Increase dialog height to accommodate larger keyboard buttons
     h = 850;  // Increased from 780 to make room for bigger buttons
     // Increase button height for larger keyboard


### PR DESCRIPTION
- **Add comment keyboard enlarged and widened (12-09-2025)**
  - Increased OrderCommentDialog width from 950 to 1800 pixels (almost full screen on 1920x1080 displays), button height from 90 to 110 pixels, and dialog height from 780 to 850 pixels for maximum usability.
  - **Files modified**:
    - `zone/dialog_zone.cc`