### PR TITLE
Fix build error: remove remaining benchmark_texture_loading() call

### DIFF
--- a/term/term_view.cc
+++ b/term/term_view.cc
@@ -4389,10 +4389,7 @@ int OpenTerm(const char* display, TouchScreen *ts, int is_term_local, int term_h
     // Set up textures - preload commonly used ones
     texture_manager.preload_common_textures();
 
-    // Run benchmark in debug mode (selective testing only)
-#ifdef DEBUG
-    texture_manager.benchmark_texture_loading();
-#endif
+    // Performance monitoring removed for production efficiency
     ReadScreenSaverPix();
 
     // Add Iconify Button


### PR DESCRIPTION
- Removed orphaned method call that was causing clang++ compilation failure
- Method was part of performance monitoring system that was cleaned up
- Build now succeeds for all targets (vt_main, vt_term, etc.)