### PR TITLE
Change Release build optimization from -Os to -O2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,11 +43,15 @@ if(VT_STRIP_BINARIES)
     message(STATUS "Binary stripping enabled for Release/RelWithDebInfo")
 endif()
 
-# Enable additional size optimizations
-set(_vt_size_flags "-Os -fmerge-all-constants -fomit-frame-pointer")
-set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} ${_vt_size_flags}")
-set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} ${_vt_size_flags}")
-message(STATUS "Size optimization flags enabled for Release builds")
+# Enable additional optimizations (replace -O3 with -O2 for better prefetch-loop-arrays support)
+set(_vt_optimization_flags "-fmerge-all-constants -fomit-frame-pointer")
+# Replace -O3 with -O2 in Release flags
+string(REPLACE "-O3" "-O2" CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE}")
+string(REPLACE "-O3" "-O2" CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE}")
+# Append additional optimization flags
+set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} ${_vt_optimization_flags}")
+set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} ${_vt_optimization_flags}")
+message(STATUS "Optimization flags enabled for Release builds (using -O2)")
 
 
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -77,6 +77,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
   - Spanish language support now covers 100% of user-facing text in ViewTouch POS system
 
 ### Changed
+- **Build System Optimization Level Change (12-15-2025)**
+  - Changed Release build optimization from `-Os` (optimize for size) to `-O2` (optimize for speed)
+  - This change enables `-fprefetch-loop-arrays` to work properly, as it may not function correctly with `-Os`
+  - Replaced CMake's default `-O3` with `-O2` in Release builds for better compatibility with prefetch optimizations
+  - Maintains other optimization flags: `-fmerge-all-constants` and `-fomit-frame-pointer`
+  - Verified that `-O2` is correctly applied in Release build configurations
+  - **Files modified**: `CMakeLists.txt`
 - **Enhanced Deposit/Book Balance Report for Accountants (12-15-2025)**
   - Significantly improved the Deposit/Book Balance report with accountant-friendly features
   - Added Executive Summary section with key financial metrics at a glance:


### PR DESCRIPTION
- Changed optimization level from -Os (optimize for size) to -O2 (optimize for speed)
- Enables -fprefetch-loop-arrays to work properly, as it may not function correctly with -Os
- Replaces CMake's default -O3 with -O2 in Release builds for better compatibility
- Maintains other optimization flags: -fmerge-all-constants and -fomit-frame-pointer
- Updated changelog.md with build system optimization change