### PR TITLE
Improve error messages and user guidance for first-time installers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,11 @@ cmake_minimum_required(VERSION 3.10)
 
 project(ViewTouch)
 message(STATUS "CMake version ${CMAKE_VERSION}")
+message(STATUS "")
+message(STATUS "ViewTouch Build Configuration")
+message(STATUS "==============================")
+message(STATUS "If you encounter missing dependency errors, run: ./check_dependencies.sh")
+message(STATUS "")
 
 # Default to an optimized build unless the user explicitly asks otherwise.
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
@@ -285,6 +290,15 @@ add_library(image_data STATIC
     src/core/image_data.cc src/core/image_data.hh)
 
 find_package(ZLIB REQUIRED)
+if(NOT ZLIB_FOUND)
+    message(FATAL_ERROR "\n"
+        "ZLIB library not found. Please install:\n"
+        "  Debian/Ubuntu: sudo apt-get install zlib1g-dev\n"
+        "  Fedora/RHEL:   sudo dnf install zlib-devel\n"
+        "  Arch Linux:    sudo pacman -S zlib\n"
+        "\n"
+        "Run './check_dependencies.sh' for a complete dependency check.\n")
+endif()
 target_link_libraries(conf_file PRIVATE ZLIB::ZLIB)
 
 set(VT_XLIBS X11)
@@ -292,6 +306,15 @@ find_package(${VT_XLIBS} REQUIRED)
 set(VT_XLIBS_INCLUDE_DIRS ${X11_INCLUDE_DIR})
 
 find_package(Motif REQUIRED) # Library Xm must be linked before Xmu
+if(NOT Motif_FOUND)
+    message(FATAL_ERROR "\n"
+        "Motif library not found. Please install:\n"
+        "  Debian/Ubuntu: sudo apt-get install libmotif-dev\n"
+        "  Fedora/RHEL:   sudo dnf install openmotif-devel\n"
+        "  Arch Linux:    sudo pacman -S openmotif\n"
+        "\n"
+        "Run './check_dependencies.sh' for a complete dependency check.\n")
+endif()
 list(APPEND VT_XLIBS ${MOTIF_LIBRARIES})
 list(APPEND VT_XLIBS_INCLUDE_DIRS ${MOTIF_INCLUDE_DIR})
 
@@ -307,11 +330,26 @@ if(DEFINED x11_missing_requirements)
     foreach(x11_lib_missing ${x11_missing_requirements})
         message(STATUS "X11: ${x11_lib_missing} library missing")
     endforeach()
-    message(FATAL_ERROR "Missing X library dependencies")
+    message(FATAL_ERROR "\n"
+        "Missing X library dependencies. Please install the required packages:\n"
+        "  Debian/Ubuntu: sudo apt-get install libx11-dev libxft-dev libxmu-dev libxpm-dev libxrender-dev libxt-dev\n"
+        "  Fedora/RHEL:   sudo dnf install libX11-devel libXft-devel libXmu-devel libXpm-devel libXrender-devel libXt-devel\n"
+        "  Arch Linux:    sudo pacman -S libx11 libxft libxmu libxpm libxrender libxt\n"
+        "\n"
+        "Run './check_dependencies.sh' for a complete dependency check and installation instructions.\n")
 endif()
 list(APPEND VT_XLIBS ${x11_required_libraries})
 
 find_package(Freetype REQUIRED)
+if(NOT Freetype_FOUND AND NOT TARGET Freetype::Freetype)
+    message(FATAL_ERROR "\n"
+        "Freetype library not found. Please install:\n"
+        "  Debian/Ubuntu: sudo apt-get install libfreetype6-dev\n"
+        "  Fedora/RHEL:   sudo dnf install freetype-devel\n"
+        "  Arch Linux:    sudo pacman -S freetype2\n"
+        "\n"
+        "Run './check_dependencies.sh' for a complete dependency check.\n")
+endif()
 if(TARGET Freetype::Freetype) # prefer target
 	list(APPEND VT_XLIBS Freetype::Freetype)
 else() # fall back to variables
@@ -321,6 +359,15 @@ endif()
 
 find_package(PkgConfig REQUIRED) # https://cmake.org/cmake/help/latest/module/FindPkgConfig.html
 pkg_check_modules(FONTCONFIG REQUIRED fontconfig)
+if(NOT FONTCONFIG_FOUND)
+    message(FATAL_ERROR "\n"
+        "Fontconfig library not found. Please install:\n"
+        "  Debian/Ubuntu: sudo apt-get install libfontconfig1-dev\n"
+        "  Fedora/RHEL:   sudo dnf install fontconfig-devel\n"
+        "  Arch Linux:    sudo pacman -S fontconfig\n"
+        "\n"
+        "Run './check_dependencies.sh' for a complete dependency check.\n")
+endif()
 list(APPEND VT_XLIBS ${FONTCONFIG_LIBRARIES})
 list(APPEND VT_XLIBS_INCLUDE_DIRS ${FONTCONFIG_INCLUDE_DIRS})
 

--- a/README.md
+++ b/README.md
@@ -54,54 +54,6 @@ ViewTouch is a powerful, open-source Point of Sale system designed specifically 
 
 [Download the latest ViewTouch image](http://www.viewtouch.com/nc.html) for Raspberry Pi (4 or 5). Write the image to a 32GB or larger microSD card, and boot directly to the ViewTouch desktop with full POS functionality.
 
-### Build from Source
-
-#### Installing Dependencies
-
-ViewTouch requires several system libraries and development tools. To check which dependencies are installed and get installation instructions, run:
-
-```bash
-# Using the wrapper script (recommended)
-./check_dependencies.sh
-
-# Or directly with CMake
-cmake -P cmake/install_dependencies.cmake
-```
-
-This script will:
-- Detect your Linux distribution
-- Check which dependencies are installed
-- Provide installation commands for missing packages
-
-**Quick install commands for common distributions:**
-
-**Debian/Ubuntu:**
-```bash
-sudo apt-get update && sudo apt-get install -y \
-    cmake build-essential git \
-    libx11-dev libxft-dev libxmu-dev libxpm-dev libxrender-dev libxt-dev \
-    libmotif-dev libfreetype6-dev libfontconfig1-dev zlib1g-dev \
-    libpng-dev libjpeg-dev libgif-dev pkg-config
-```
-
-**Fedora/RHEL/CentOS:**
-```bash
-sudo dnf install -y \
-    cmake gcc gcc-c++ make git \
-    libX11-devel libXft-devel libXmu-devel libXpm-devel libXrender-devel libXt-devel \
-    openmotif-devel freetype-devel fontconfig-devel zlib-devel \
-    libpng-devel libjpeg-devel giflib-devel pkgconfig
-```
-
-**Arch Linux:**
-```bash
-sudo pacman -S --noconfirm \
-    cmake base-devel git \
-    libx11 libxft libxmu libxpm libxrender libxt \
-    openmotif freetype2 fontconfig zlib \
-    libpng libjpeg-turbo giflib pkgconf
-```
-
 #### Building
 
 See the [Wiki](../../wiki) for detailed build instructions and development setup.


### PR DESCRIPTION
- Add helpful error messages in CMakeLists.txt that guide users when dependencies are missing
- Error messages include installation commands for Debian/Ubuntu, Fedora/RHEL, and Arch Linux
- Add startup message in CMake configuration pointing users to check_dependencies.sh
- Improve dependency checking with better error handling for ZLIB, Motif, Freetype, Fontconfig, and X11 libraries