### PR TITLE
Document changelog entries and fix blank kitchen/bar video checks

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -19,6 +19,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
   - Replaced the previous interactive/TUI `build.sh` with a simplified terminal-only helper that detects the distribution's package manager, installs missing build dependencies, and runs CMake configure → build → install.
   - Removed duplicate content and GUI/TUI helper code; made `build.sh` executable.
   - Files modified: `build.sh`
+ - **Reports/UI: Add `Report::TextKV`/`TextKVMid` and refactor report/zone outputs** (2026-04-14)
+   - Added `Report::TextKV()` and `Report::TextKVMid()` helpers to simplify label/value printing in reports (`main/ui/report.hh`, `main/ui/report.cc`).
+   - Redesigned the `System::DepositReport()` printed layout for clearer 80-column output and reconciliation sections (`main/ui/system_report.cc`).
+   - Converted many simple left/right label/value callsites to use `TextKV`/`TextKVMid` (reports) or `TextLR` (on-screen zones) to unify alignment and reduce duplication across the UI and printed reports.
+   - Fixed a misleading indentation/guarding bug in `zone/inventory_zone.cc`.
+   - Files modified (selected): `main/ui/report.hh`, `main/ui/report.cc`, `main/ui/system_report.cc`, `main/business/check.cc`, `zone/payment_zone.cc`, `zone/order_zone.cc`, `zone/inventory_zone.cc`, `zone/drawer_zone.cc`, `zone/table_zone.cc`, `zone/phrase_zone.cc`, `zone/payout_zone.cc`, `zone/settings_zone.cc`, `zone/user_edit_zone.cc`.
+   - Follow-up: finish the payment-entry sweep, add unit tests for Deposit/Book Balance output, and update translations.
 
 ### Fixed
  - **Video Display: Prevent blank checks on Bar/Kitchen video (2026-04-14)**

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -21,6 +21,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
   - Files modified: `build.sh`
 
 ### Fixed
+ - **Video Display: Prevent blank checks on Bar/Kitchen video (2026-04-14)**
+   - Fixed bug where an empty check header could be displayed on Bar/Kitchen video when orders had been removed or when new items were added but not sent.
+   - `ReportZone::ShowCheck()` now uses `Check::PrintCount(..., ORDER_SHOWN)` to ensure the check contains printable (sent and not-yet-shown) items for the specific video target before selecting it for display.
+   - Files modified: `zone/report_zone.cc`
+   - Impact: Video zones will no longer show blank check headers unless there are actual printable items for that target.
+
 - **Video Display: Keep Bar and Kitchen video checks independent when served/marked done (2026-04-14)**
   - Prevented marking orders for the entire check as shown when serving from a single video display.
   - Scoped `ORDER_SHOWN` to only orders whose `Order::VideoTarget(settings)` matches the active `video_target` (bar vs kitchen/default).

--- a/main/business/check.cc
+++ b/main/business/check.cc
@@ -1597,10 +1597,8 @@ int Check::PrintWorkOrder(Terminal *term, Report *report, int printer_id, int re
                 }
                 
                 report->Mode(kitchen_mode);
-                report->TextL(ordstr, order_color);
-                report->TextR(cststr, COLOR_DEFAULT);
+                report->TextKV(ordstr, cststr, order_color, COLOR_DEFAULT);
                 report->Mode(0);
-                report->NewLine();
 
                 ordstr[0] = '\0';
                 str2[0] = '\0';
@@ -1618,10 +1616,8 @@ int Check::PrintWorkOrder(Terminal *term, Report *report, int printer_id, int re
                         {
                             // write out the line for newline mode
                             report->Mode(kitchen_mode);
-                            report->TextL(str2, COLOR_RED);
-                            report->TextR("", COLOR_RED);
+                            report->TextKV(str2, "", COLOR_RED, COLOR_RED);
                             report->Mode(0);
-                            report->NewLine();
                         }
                         else
                         {
@@ -1634,10 +1630,8 @@ int Check::PrintWorkOrder(Terminal *term, Report *report, int printer_id, int re
                             {
                                 vt_safe_string::safe_concat(tmpstr, STRLONG, ",");
                                 report->Mode(kitchen_mode);
-                                report->TextL(tmpstr, COLOR_RED);
-                                report->TextR("", COLOR_RED);
-                                report->Mode(0);
-                                report->NewLine();
+                                    report->TextKV(tmpstr, "", COLOR_RED, COLOR_RED);
+                                    report->Mode(0);
                                 ordstr[0] = '\0';
                                 vt_safe_string::safe_concat(ordstr, STRLENGTH, "  ");
                                 vt_safe_string::safe_concat(ordstr, STRLENGTH, str2);
@@ -1649,10 +1643,8 @@ int Check::PrintWorkOrder(Terminal *term, Report *report, int printer_id, int re
                 if (settings->mod_separator == MOD_SEPARATE_CM && ordstr[0] != '\0')
                 {
                     report->Mode(kitchen_mode);
-                    report->TextL(ordstr, COLOR_RED);
-                    report->TextR("", COLOR_RED);
+                    report->TextKV(ordstr, "", COLOR_RED, COLOR_RED);
                     report->Mode(0);
-                    report->NewLine();
                 }
             }
         }
@@ -2459,8 +2451,7 @@ int Check::MakeReport(Terminal *term, Report *report, int show_what, int video_t
                         if (order->status & ORDER_COMP)
                         {
                             report->NewLine();
-                            report->TextPosR(-8, GlobalTranslate("COMP"));
-                            report->TextR(term->FormatPrice(-order->cost, 1), COLOR_RED);
+                            report->TextKV(GlobalTranslate("COMP"), term->FormatPrice(-order->cost, 1), COLOR_DEFAULT, COLOR_RED);
                         }
                     }
                 }
@@ -2542,14 +2533,10 @@ int Check::MakeReport(Terminal *term, Report *report, int show_what, int video_t
             int tax = sc->TotalTax();
             if (tax)
             {
-                report->TextPosR(-8, GlobalTranslate("Tax"));
-                report->TextR(term->FormatPrice(tax, 1));
-                report->NewLine();
+                report->TextKV(GlobalTranslate("Tax"), term->FormatPrice(tax, 1));
                 if (sc->IsTaxExempt())
                 {
-                    report->TextPosR(-8, GlobalTranslate("Tax Exempt"));
-                    report->TextR(term->FormatPrice(-tax, 1));
-                    report->NewLine();
+                    report->TextKV(GlobalTranslate("Tax Exempt"), term->FormatPrice(-tax, 1));
                     vt_safe_string::safe_format(str, STRLONG, "%s:  %s", GlobalTranslate("Tax ID"), sc->tax_exempt.Value());
                     report->Mode(PRINT_BOLD);
                     report->TextL(str);
@@ -2558,9 +2545,7 @@ int Check::MakeReport(Terminal *term, Report *report, int show_what, int video_t
                     tax = 0;
                 }
             }
-            report->TextPosR(-8, GlobalTranslate("Total"));
-            report->TextR(term->FormatPrice(sc->total_sales + tax - sc->item_comps, 1));
-            report->NewLine();
+            report->TextKV(GlobalTranslate("Total"), term->FormatPrice(sc->total_sales + tax - sc->item_comps, 1));
             
             if (sc->PaymentList())
             {
@@ -2568,22 +2553,16 @@ int Check::MakeReport(Terminal *term, Report *report, int show_what, int video_t
                 Payment *payptr = sc->PaymentList();
                 while (payptr)
                 {
-                    report->TextL(payptr->Description(settings));
-                    report->TextR(term->FormatPrice(payptr->value, 1));
-                    report->NewLine();
+                    report->TextKV(payptr->Description(settings), term->FormatPrice(payptr->value, 1));
                     payptr = payptr->next;
                 }
                 
                 report->TextR("------");
                 report->NewLine();
-                report->TextPosR(-8, term->Translate("Amount Tendered"));
-                report->TextR(term->FormatPrice(sc->payment, 1));
-                report->NewLine();
+                report->TextKV(term->Translate("Amount Tendered"), term->FormatPrice(sc->payment, 1));
                 if (sc->balance > 0)
                 {
-                    report->TextPosR(-8, term->Translate("Balance Due"));
-                    report->TextR(term->FormatPrice(sc->balance, 1));
-                    report->NewLine();
+                    report->TextKV(term->Translate("Balance Due"), term->FormatPrice(sc->balance, 1));
                 }
             }
         }

--- a/main/business/employee.cc
+++ b/main/business/employee.cc
@@ -591,9 +591,7 @@ int UserDB::ListReport(Terminal *t, int active, Report *r)
                 vt_safe_string::safe_concat(str, 256, str2);
             }
 
-            r->TextL(str, col);
-            r->TextR(FormatPhoneNumber(e->phone), col);
-            r->NewLine();
+            r->TextKV(str, FormatPhoneNumber(e->phone), col, col);
             ++count;
         }
     }

--- a/main/hardware/drawer.cc
+++ b/main/hardware/drawer.cc
@@ -533,37 +533,35 @@ int Drawer::MakeReport(Terminal *my_term, Check *check_list, Report *r)
         total_entered += cash_entered;
     }
 
-    r->TextL(term->Translate("Starting Balance"));
+    // Starting Balance (show entered if balanced in mid column)
+    vt_safe_string::safe_copy(str, 256, "");
     if (balanced)
-        r->TextPosR(COL, term->FormatPrice(cash_float));
-    r->TextR(term->FormatPrice(cash_float));
-    r->NewLine();
+        vt_safe_string::safe_copy(str, 256, term->FormatPrice(cash_float));
+    r->TextKVMid(term->Translate("Starting Balance"), str, term->FormatPrice(cash_float), COL);
 
     if (tip_a)
     {
-        r->TextL(term->Translate("Cash Before Tip Payout"));
+        // Cash before tips and tips paid
         if (balanced)
-            r->TextPosR(COL, term->FormatPrice(cash_entered + tip_a));
+            vt_safe_string::safe_copy(str, 256, term->FormatPrice(cash_entered + tip_a));
         else
-            r->TextPosR(COL, term->FormatPrice(cash_count));
-        r->TextR(term->FormatPrice(cash_amount + tip_a));
-        r->NewLine();
+            vt_safe_string::safe_copy(str, 256, term->FormatPrice(cash_count));
+        r->TextKVMid(term->Translate("Cash Before Tip Payout"), str, term->FormatPrice(cash_amount + tip_a), COL);
 
-        r->TextL(term->Translate("Tips Paid out"));
+        vt_safe_string::safe_copy(str, 256, "");
         if (balanced)
-            r->TextPosR(COL, term->FormatPrice(tip_a));
-        r->TextR(term->FormatPrice(tip_a));
-        r->NewLine();
+            vt_safe_string::safe_copy(str, 256, term->FormatPrice(tip_a));
+        r->TextKVMid(term->Translate("Tips Paid out"), str, term->FormatPrice(tip_a), COL);
+        
 
     }
 
-    r->TextL(term->Translate("Cash"));
+    // Cash line
     if (balanced)
-        r->TextPosR(COL, term->FormatPrice(cash_entered));
+        vt_safe_string::safe_copy(str, 256, term->FormatPrice(cash_entered));
     else
-        r->NumberPosR(COL, cash_count);
-    r->TextR(term->FormatPrice(cash_amount));
-    r->NewLine();
+        vt_safe_string::safe_format(str, 256, "%d", cash_count);
+    r->TextKVMid(term->Translate("Cash"), str, term->FormatPrice(cash_amount), COL);
 
     // Check
     int check_amount = 0;
@@ -578,13 +576,11 @@ int Drawer::MakeReport(Terminal *my_term, Check *check_list, Report *r)
         total_amount  += check_amount;
         total_count   += check_count;
         total_entered += check_entered;
-        r->TextL(term->Translate("Check"));
         if (balanced)
-            r->TextPosR(COL, term->FormatPrice(check_entered));
+            vt_safe_string::safe_copy(str, 256, term->FormatPrice(check_entered));
         else
-            r->NumberPosR(COL, check_count);
-        r->TextR(term->FormatPrice(check_amount));
-        r->NewLine();
+            vt_safe_string::safe_format(str, 256, "%d", check_count);
+        r->TextKVMid(term->Translate("Check"), str, term->FormatPrice(check_amount), COL);
     }
 
     // Gift Cert.
@@ -594,13 +590,11 @@ int Drawer::MakeReport(Terminal *my_term, Check *check_list, Report *r)
         total_amount  += db->amount;
         total_count   += db->count;
         total_entered += db->entered;
-        r->TextL(term->Translate("Gift Certificate"));
         if (balanced)
-            r->TextPosR(COL, term->FormatPrice(db->entered));
+            vt_safe_string::safe_copy(str, 256, term->FormatPrice(db->entered));
         else
-            r->NumberPosR(COL, db->count);
-        r->TextR(term->FormatPrice(db->amount));
-        r->NewLine();
+            vt_safe_string::safe_format(str, 256, "%d", db->count);
+        r->TextKVMid(term->Translate("Gift Certificate"), str, term->FormatPrice(db->amount), COL);
     }
 
     // Expense Payments
@@ -618,12 +612,11 @@ int Drawer::MakeReport(Terminal *my_term, Check *check_list, Report *r)
     // SubTotal
     r->TextR("--------");
     r->NewLine();
-    r->TextL(term->Translate("SubTotal"));
     if (balanced)
-        r->TextPosR(COL, term->FormatPrice(total_entered));
+        vt_safe_string::safe_copy(str, 256, term->FormatPrice(total_entered));
     else
-        r->NumberPosR(COL, total_count);
-    r->TextR(term->FormatPrice(total_amount));
+        vt_safe_string::safe_format(str, 256, "%d", total_count);
+    r->TextKVMid(term->Translate("SubTotal"), str, term->FormatPrice(total_amount), COL);
     r->NewLine(2);
 
     //NOTE->BAK Support both the original credit card method as well
@@ -638,13 +631,11 @@ int Drawer::MakeReport(Terminal *my_term, Check *check_list, Report *r)
             credit_amount  += db->amount;
             credit_count   += db->count;
             credit_entered += db->entered;
-            r->TextL(cc->name.Value());
             if (balanced)
-                r->TextPosR(COL, term->FormatPrice(db->entered));
+                vt_safe_string::safe_copy(str, 256, term->FormatPrice(db->entered));
             else
-                r->NumberPosR(COL, db->count);
-            r->TextR(term->FormatPrice(db->amount));
-            r->NewLine();
+                vt_safe_string::safe_format(str, 256, "%d", db->count);
+            r->TextKVMid(cc->name.Value(), str, term->FormatPrice(db->amount), COL);
         }
     }
 
@@ -658,13 +649,11 @@ int Drawer::MakeReport(Terminal *my_term, Check *check_list, Report *r)
             credit_amount  += db->amount;
             credit_count   += db->count;
             credit_entered += db->entered;
-            r->TextL(CreditCardName[idx]);
             if (balanced)
-                r->TextPosR(COL, term->FormatPrice(db->entered));
+                vt_safe_string::safe_copy(str, 256, term->FormatPrice(db->entered));
             else
-                r->NumberPosR(COL, db->count);
-            r->TextR(term->FormatPrice(db->amount));
-            r->NewLine();
+                vt_safe_string::safe_format(str, 256, "%d", db->count);
+            r->TextKVMid(CreditCardName[idx], str, term->FormatPrice(db->amount), COL);
         }
         idx += 1;
     }
@@ -676,13 +665,12 @@ int Drawer::MakeReport(Terminal *my_term, Check *check_list, Report *r)
         credit_amount += db->amount;
         credit_count += db->count;
         credit_entered += db->entered;
-        r->TextL(term->Translate(FindStringByValue(CARD_TYPE_DEBIT, CardTypeValue, CardTypeName)));
         if (balanced)
-            r->TextPosR(COL, term->FormatPrice(db->entered));
+            vt_safe_string::safe_copy(str, 256, term->FormatPrice(db->entered));
         else
-            r->NumberPosR(COL, db->count);
-        r->TextR(term->FormatPrice(db->amount));
-        r->NewLine();
+            vt_safe_string::safe_format(str, 256, "%d", db->count);
+        r->TextKVMid(term->Translate(FindStringByValue(CARD_TYPE_DEBIT, CardTypeValue, CardTypeName)),
+                     str, term->FormatPrice(db->amount), COL);
     }
 
     // Credit Card total
@@ -693,24 +681,21 @@ int Drawer::MakeReport(Terminal *my_term, Check *check_list, Report *r)
         total_entered += credit_entered;
         r->TextR("--------");
         r->NewLine();
-        r->TextL(term->Translate("Total C.Cards"));
         if (balanced)
-            r->TextPosR(COL, term->FormatPrice(credit_entered));
+            vt_safe_string::safe_copy(str, 256, term->FormatPrice(credit_entered));
         else
-            r->NumberPosR(COL, credit_count);
-        r->TextR(term->FormatPrice(credit_amount));
-        r->NewLine();
+            vt_safe_string::safe_format(str, 256, "%d", credit_count);
+        r->TextKVMid(term->Translate("Total C.Cards"), str, term->FormatPrice(credit_amount), COL);
     }
 
     // Drawer Balance
     r->TextR("--------");
     r->NewLine();
-    r->TextL(term->Translate("Drawer Balance"));
     if (balanced)
-        r->TextPosR(COL, term->FormatPrice(total_entered));
+        vt_safe_string::safe_copy(str, 256, term->FormatPrice(total_entered));
     else
-        r->NumberPosR(COL, total_count);
-    r->TextR(term->FormatPrice(total_amount));
+        vt_safe_string::safe_format(str, 256, "%d", total_count);
+    r->TextKVMid(term->Translate("Drawer Balance"), str, term->FormatPrice(total_amount), COL);
     r->NewLine(2);
 
     // Discounts
@@ -723,13 +708,11 @@ int Drawer::MakeReport(Terminal *my_term, Check *check_list, Report *r)
             dis_amount  += db->amount;
             dis_count   += db->count;
             dis_entered += db->entered;
-            r->TextL(cp->name.Value());
             if (balanced)
-                r->TextPosR(COL, term->FormatPrice(db->entered));
+                vt_safe_string::safe_copy(str, 256, term->FormatPrice(db->entered));
             else
-                r->NumberPosR(COL, db->count);
-            r->TextR(term->FormatPrice(db->amount));
-            r->NewLine();
+                vt_safe_string::safe_format(str, 256, "%d", db->count);
+            r->TextKVMid(cp->name.Value(), str, term->FormatPrice(db->amount), COL);
         }
     }
 
@@ -740,23 +723,24 @@ int Drawer::MakeReport(Terminal *my_term, Check *check_list, Report *r)
         {
             dis_amount += db->amount;
             dis_count  += db->count;
-            r->TextL(cm->name.Value());
+            // Comp entry: mid value depends on media_balanced and balanced
             if (media_balanced & (1<<TENDER_COMP))
             {
                 dis_entered += db->entered;
                 if (balanced)
-                    r->TextPosR(COL, term->FormatPrice(db->entered));
+                    vt_safe_string::safe_copy(str, 256, term->FormatPrice(db->entered));
                 else
-                    r->NumberPosR(COL, db->count);
+                    vt_safe_string::safe_format(str, 256, "%d", db->count);
             }
             else
             {
                 dis_entered += db->amount;
                 if (!balanced)
-                    r->NumberPosR(COL, db->count);
+                    vt_safe_string::safe_format(str, 256, "%d", db->count);
+                else
+                    vt_safe_string::safe_copy(str, 256, "");
             }
-            r->TextR(term->FormatPrice(db->amount));
-            r->NewLine();
+            r->TextKVMid(cm->name.Value(), str, term->FormatPrice(db->amount), COL);
         }
     }
 
@@ -765,23 +749,23 @@ int Drawer::MakeReport(Terminal *my_term, Check *check_list, Report *r)
     {
         dis_amount += db->amount;
         dis_count  += db->count;
-        r->TextL(term->Translate("Item Comps"));
         if (media_balanced & (1<<TENDER_ITEM_COMP))
         {
             dis_entered += db->entered;
             if (balanced)
-                r->TextPosR(COL, term->FormatPrice(db->entered));
+                vt_safe_string::safe_copy(str, 256, term->FormatPrice(db->entered));
             else
-                r->NumberPosR(COL, db->count);
+                vt_safe_string::safe_format(str, 256, "%d", db->count);
         }
         else
         {
             dis_entered += db->amount;
             if (!balanced)
-                r->NumberPosR(COL, db->count);
+                vt_safe_string::safe_format(str, 256, "%d", db->count);
+            else
+                vt_safe_string::safe_copy(str, 256, "");
         }
-        r->TextR(term->FormatPrice(db->amount));
-        r->NewLine();
+        r->TextKVMid(term->Translate("Item Comps"), str, term->FormatPrice(db->amount), COL);
     }
 
     for (DiscountInfo *ds = s->DiscountList(); ds != nullptr; ds = ds->next)
@@ -791,23 +775,23 @@ int Drawer::MakeReport(Terminal *my_term, Check *check_list, Report *r)
         {
             dis_amount += db->amount;
             dis_count  += db->count;
-            r->TextL(ds->name.Value());
             if (media_balanced & (1<<TENDER_DISCOUNT))
             {
                 dis_entered += db->entered;
                 if (balanced)
-                    r->TextPosR(COL, term->FormatPrice(db->entered));
+                    vt_safe_string::safe_copy(str, 256, term->FormatPrice(db->entered));
                 else
-                    r->NumberPosR(COL, db->count);
+                    vt_safe_string::safe_format(str, 256, "%d", db->count);
             }
             else
             {
                 dis_entered += db->amount;
                 if (!balanced)
-                    r->NumberPosR(COL, db->count);
+                    vt_safe_string::safe_format(str, 256, "%d", db->count);
+                else
+                    vt_safe_string::safe_copy(str, 256, "");
             }
-            r->TextR(term->FormatPrice(db->amount));
-            r->NewLine();
+            r->TextKVMid(ds->name.Value(), str, term->FormatPrice(db->amount), COL);
         }
     }
 
@@ -818,23 +802,23 @@ int Drawer::MakeReport(Terminal *my_term, Check *check_list, Report *r)
         {
             dis_amount += db->amount;
             dis_count  += db->count;
-            r->TextL(mi->name.Value());
             if (media_balanced & (1<<TENDER_EMPLOYEE_MEAL))
             {
                 dis_entered += db->entered;
                 if (balanced)
-                    r->TextPosR(COL, term->FormatPrice(db->entered));
+                    vt_safe_string::safe_copy(str, 256, term->FormatPrice(db->entered));
                 else
-                    r->NumberPosR(COL, db->count);
+                    vt_safe_string::safe_format(str, 256, "%d", db->count);
             }
             else
             {
                 dis_entered += db->amount;
                 if (!balanced)
-                    r->NumberPosR(COL, db->count);
+                    vt_safe_string::safe_format(str, 256, "%d", db->count);
+                else
+                    vt_safe_string::safe_copy(str, 256, "");
             }
-            r->TextR(term->FormatPrice(db->amount));
-            r->NewLine();
+            r->TextKVMid(mi->name.Value(), str, term->FormatPrice(db->amount), COL);
         }
     }
 
@@ -844,10 +828,11 @@ int Drawer::MakeReport(Terminal *my_term, Check *check_list, Report *r)
         dis_amount  += db->amount;
         dis_count   += db->count;
         dis_entered += db->amount;
-        r->TextL(term->Translate("Money Lost"));
         if (!balanced)
-            r->NumberPosR(COL, db->count);
-        r->TextR(term->FormatPrice(db->amount));
+            vt_safe_string::safe_format(str, 256, "%d", db->count);
+        else
+            vt_safe_string::safe_copy(str, 256, "");
+        r->TextKVMid(term->Translate("Money Lost"), str, term->FormatPrice(db->amount), COL);
         r->NewLine();
     }
 
@@ -855,12 +840,11 @@ int Drawer::MakeReport(Terminal *my_term, Check *check_list, Report *r)
     {
         r->TextR("--------");
         r->NewLine();
-        r->TextL(term->Translate("Total Discounts"));
         if (balanced)
-            r->TextPosR(COL, term->FormatPrice(dis_entered));
+            vt_safe_string::safe_copy(str, 256, term->FormatPrice(dis_entered));
         else
-            r->NumberPosR(COL, dis_count);
-        r->TextR(term->FormatPrice(dis_amount));
+            vt_safe_string::safe_format(str, 256, "%d", dis_count);
+        r->TextKVMid(term->Translate("Total Discounts"), str, term->FormatPrice(dis_amount), COL);
         r->NewLine(2);
     }
     r->Mode(0);
@@ -893,33 +877,36 @@ int Drawer::MakeReport(Terminal *my_term, Check *check_list, Report *r)
         r->NewLine();
 
     // Deposit Amounts
-    r->TextL(term->Translate("Cash"));
+    // Deposit amounts: Cash, Check, Expenses
     if (balanced)
-        r->TextPosR(COL, term->FormatPrice(cash_entered));
-    r->TextR(term->FormatPrice(cash_amount));
-    r->NewLine();
+        vt_safe_string::safe_copy(str, 256, term->FormatPrice(cash_entered));
+    else
+        vt_safe_string::safe_copy(str, 256, "");
+    r->TextKVMid(term->Translate("Cash"), str, term->FormatPrice(cash_amount), COL);
 
-    r->TextL(term->Translate("Check"));
     if (balanced)
-        r->TextPosR(COL, term->FormatPrice(check_entered));
-    r->TextR(term->FormatPrice(check_amount));
-    r->NewLine();
+        vt_safe_string::safe_copy(str, 256, term->FormatPrice(check_entered));
+    else
+        vt_safe_string::safe_copy(str, 256, "");
+    r->TextKVMid(term->Translate("Check"), str, term->FormatPrice(check_amount), COL);
 
-    r->TextL(term->Translate("Expenses"));
     if (balanced)
-        r->TextPosR(COL, term->FormatPrice(-pay_entered));
-    r->TextR(term->FormatPrice(-pay_amount));
+        vt_safe_string::safe_copy(str, 256, term->FormatPrice(-pay_entered));
+    else
+        vt_safe_string::safe_copy(str, 256, "");
+    r->TextKVMid(term->Translate("Expenses"), str, term->FormatPrice(-pay_amount), COL);
     r->NewLine();
 
     total_deposit = cash_amount + check_amount;
     r->NewLine();
-    r->TextL(term->Translate("Total Deposit"));
     if (balanced)
     {
         total_entered -= cash_float;
-        r->TextPosR(COL, term->FormatPrice(total_entered));
+        vt_safe_string::safe_copy(str, 256, term->FormatPrice(total_entered));
     }
-    r->TextR(term->FormatPrice(total_deposit));
+    else
+        vt_safe_string::safe_copy(str, 256, "");
+    r->TextKVMid(term->Translate("Total Deposit"), str, term->FormatPrice(total_deposit), COL);
 
     if (balanced)
     {

--- a/main/ui/report.cc
+++ b/main/ui/report.cc
@@ -871,6 +871,28 @@ int Report::Text2Col(const std::string &text, int color, int align, float indent
     return retval;
 }
 
+int Report::TextKV(const std::string &label, const std::string &value,
+                   int label_color, int value_color)
+{
+    FnTrace("Report::TextKV()");
+    TextPosL(3, label, label_color);
+    TextPosR(0, value, value_color);
+    NewLine();
+    return 0;
+}
+
+int Report::TextKVMid(const std::string &label, const std::string &mid, const std::string &right,
+                      int midPos, int label_color, int mid_color, int right_color)
+{
+    FnTrace("Report::TextKVMid()");
+    TextL(label, label_color);
+    // midPos passed through to TextPosR; negative midPos will align relative to right edge like original code
+    TextPosR(midPos, mid, mid_color);
+    TextPosR(0, right, right_color);
+    NewLine();
+    return 0;
+}
+
 int Report::Number(int n, int c, int a, float indent)
 {
     FnTrace("Report::Number()");

--- a/main/ui/report.hh
+++ b/main/ui/report.hh
@@ -216,6 +216,15 @@ public:
     int UnderlinePosR(int pos, int len = 0, int c = COLOR_DEFAULT)
     { return Underline(len, c, ALIGN_RIGHT, static_cast<float>(pos)); }
 
+    // Convenience helper: Left label and right value on same line
+    int TextKV(const std::string &label, const std::string &value,
+               int label_color = COLOR_DEFAULT, int value_color = COLOR_DEFAULT);
+
+    // Convenience helper: Left label, middle value at given midPos, and right value
+    int TextKVMid(const std::string &label, const std::string &mid, const std::string &right,
+                  int midPos, int label_color = COLOR_DEFAULT,
+                  int mid_color = COLOR_DEFAULT, int right_color = COLOR_DEFAULT);
+
 };
 
 #endif

--- a/main/ui/system_report.cc
+++ b/main/ui/system_report.cc
@@ -1574,26 +1574,20 @@ int BalanceReportWorkFn(BRData *brdata)
         {
             if (term->hide_zeros == 0 || brdata->group_sales[g] != 0)
             {
-                vt::cpp23::format_to_buffer(str, sizeof(str), "{} Sales", SalesGroupName[g]);
-                thisReport->TextL(str);
-                thisReport->TextPosR(last_pos, term->FormatPrice(brdata->group_sales[g]), color);
-
+                std::string label = std::string() + SalesGroupName[g] + " Sales";
                 per = 0;
                 if (brdata->sales > 0)
                     per = 100.0 * ((Flt) brdata->group_sales[g] / (Flt) brdata->sales);
 
                 vt::cpp23::format_to_buffer(str, sizeof(str), "{:.2f}%", per);
-
-                thisReport->TextPosL(percent_pos, str, COLOR_DK_BLUE);
-                thisReport->NewLine();
+                thisReport->TextKVMid(label, str, term->FormatPrice(brdata->group_sales[g]), percent_pos,
+                                     COLOR_DEFAULT, COLOR_DK_BLUE, color);
             }
         }
 	}
 
-            thisReport->TextPosL(3, GlobalTranslate("Total Sales"));
-    thisReport->TextPosR(last_pos, term->FormatPrice(brdata->sales), color);
-    thisReport->TextPosL(percent_pos, "100%", COLOR_DK_BLUE);
-    thisReport->NewLine();
+                thisReport->TextKVMid(GlobalTranslate("Total Sales"), "100%", term->FormatPrice(brdata->sales), percent_pos,
+                           COLOR_DEFAULT, COLOR_DK_BLUE, color);
 
     // Adjustments
     thisReport->NewLine();
@@ -1614,9 +1608,7 @@ int BalanceReportWorkFn(BRData *brdata)
             {
                 if (comps->name[0] != '\0' && (comps->total != 0 || term->hide_zeros == 0))
                 {
-                    thisReport->TextPosL(3, comps->name);
-                    thisReport->TextPosR(last_pos, term->FormatPrice(comps->total), color);
-                    thisReport->NewLine();
+                    thisReport->TextKV(comps->name, term->FormatPrice(comps->total), COLOR_DEFAULT, color);
                 }
                 comps = comps->next;
             }
@@ -1643,9 +1635,7 @@ int BalanceReportWorkFn(BRData *brdata)
             {
                 if (meals->name[0] != '\0' && (meals->total != 0 || term->hide_zeros == 0))
                 {
-                    thisReport->TextPosL(3, meals->name);
-                    thisReport->TextPosR(last_pos, term->FormatPrice(meals->total), color);
-                    thisReport->NewLine();
+                    thisReport->TextKV(meals->name, term->FormatPrice(meals->total), COLOR_DEFAULT, color);
                 }
                 meals = meals->next;
             }
@@ -1665,9 +1655,7 @@ int BalanceReportWorkFn(BRData *brdata)
             {
                 if (discounts->name[0] != '\0' && (discounts->total != 0 || term->hide_zeros == 0))
                 {
-                    thisReport->TextPosL(3, discounts->name);
-                    thisReport->TextPosR(last_pos, term->FormatPrice(discounts->total), color);
-                    thisReport->NewLine();
+                    thisReport->TextKV(discounts->name, term->FormatPrice(discounts->total), COLOR_DEFAULT, color);
                 }
                 discounts = discounts->next;
             }
@@ -1687,9 +1675,7 @@ int BalanceReportWorkFn(BRData *brdata)
             {
                 if (coupons->name[0] != '\0' && (coupons->total != 0 || term->hide_zeros == 0))
                 {
-                    thisReport->TextPosL(3, coupons->name);
-                    thisReport->TextPosR(last_pos, term->FormatPrice(coupons->total), color);
-                    thisReport->NewLine();
+                    thisReport->TextKV(coupons->name, term->FormatPrice(coupons->total), COLOR_DEFAULT, color);
                 }
                 coupons = coupons->next;
             }
@@ -1823,15 +1809,11 @@ int BalanceReportWorkFn(BRData *brdata)
             if (currSettings->job_active[JobValue[j]] && (term->hide_zeros == 0 || job_mins[j] != 0))
             {
                 vt::cpp23::format_to_buffer(str, sizeof(str), "{} Cost", JobName[j]);
-                thisReport->TextL(str);
-                thisReport->TextPosR(last_pos, term->FormatPrice(job_cost[j], 1), color);
-                thisReport->NewLine();
+                thisReport->TextKV(str, term->FormatPrice(job_cost[j], 1), COLOR_DEFAULT, color);
 
                 if (job_otcost[j] > 0)
                 {
-                    thisReport->TextL(GlobalTranslate("Overtime"));
-                    thisReport->TextPosR(last_pos, term->FormatPrice(job_otcost[j], 1), color);
-                    thisReport->NewLine();
+                    thisReport->TextKV(GlobalTranslate("Overtime"), term->FormatPrice(job_otcost[j], 1), COLOR_DEFAULT, color);
                 }
             }
             ++j;
@@ -2258,53 +2240,39 @@ int System::DepositReport(Terminal *term, TimeInfo &start_time,
     report->Mode(0);
     report->NewLine();
 
-    // ===== EXECUTIVE SUMMARY SECTION (Accountant-Friendly) =====
+    // ===== EXECUTIVE SUMMARY (compact, accountant-friendly) =====
     report->NewLine();
     report->Mode(PRINT_BOLD);
     report->TextC(GlobalTranslate("EXECUTIVE SUMMARY"), COLOR_DK_BLUE);
     report->Mode(0);
     report->NewLine();
 
-    // Transaction counts
+    report->Divider('=', report->page_width > 0 ? report->page_width : report->max_width);
+
+    // Transaction counts (compact)
     if (check_count > 0 || transaction_count > 0)
     {
-        report->TextL(GlobalTranslate("Transaction Summary:"));
+        vt_safe_string::safe_format(str, 256, "%d", check_count);
+        report->TextKV(GlobalTranslate("Closed Checks"), str);
+        vt_safe_string::safe_format(str, 256, "%d", transaction_count);
+        report->TextKV(GlobalTranslate("Settled Transactions"), str);
         report->NewLine();
-        vt_safe_string::safe_format(str, 256, "  Closed Checks: %d", check_count);
-        report->TextL(str);
-        report->NewLine();
-        vt_safe_string::safe_format(str, 256, "  Settled Transactions: %d", transaction_count);
-        report->TextL(str);
-        report->NewLine(2);
     }
 
-    // Key financial metrics
+    // Key financial metrics (left label / right value)
     report->Mode(PRINT_BOLD);
-    report->TextL(GlobalTranslate("Key Financial Metrics:"), COLOR_DK_GREEN);
-    report->NewLine();
-    report->Mode(0);
-    
-    report->TextPosL(3, GlobalTranslate("Gross Sales"));
-    report->TextPosR(0, term->FormatPrice(total_sales), col);
-    report->NewLine();
-    
-    report->TextPosL(3, GlobalTranslate("Adjustments"));
-    report->TextPosR(0, term->FormatPrice(-total_adjust), COLOR_DK_RED);
-    report->NewLine();
-    
-    report->Mode(PRINT_BOLD);
-    report->TextPosL(3, GlobalTranslate("Net Sales"));
-    report->TextPosR(0, term->FormatPrice(net_sales), COLOR_DK_GREEN);
+    report->TextC(GlobalTranslate("Key Financial Metrics"), COLOR_DK_GREEN);
     report->Mode(0);
     report->NewLine();
-    
-    report->TextPosL(3, GlobalTranslate("Total Tax Collected"));
-    report->TextPosR(0, term->FormatPrice(total_tax), col);
-    report->NewLine();
-    
+
+    report->TextKV(GlobalTranslate("Gross Sales"), term->FormatPrice(total_sales), COLOR_DEFAULT, col);
+    report->TextKV(GlobalTranslate("Adjustments"), term->FormatPrice(-total_adjust), COLOR_DEFAULT, COLOR_DK_RED);
     report->Mode(PRINT_BOLD);
-    report->TextPosL(3, GlobalTranslate("Net Receipts"));
-    report->TextPosR(0, term->FormatPrice(net_receipts), COLOR_DK_GREEN);
+    report->TextKV(GlobalTranslate("Net Sales"), term->FormatPrice(net_sales), COLOR_DEFAULT, COLOR_DK_GREEN);
+    report->Mode(0);
+    report->TextKV(GlobalTranslate("Total Tax Collected"), term->FormatPrice(total_tax), COLOR_DEFAULT, col);
+    report->Mode(PRINT_BOLD);
+    report->TextKV(GlobalTranslate("Net Receipts"), term->FormatPrice(net_receipts), COLOR_DEFAULT, COLOR_DK_GREEN);
     report->Mode(0);
     report->UnderlinePosR(0, 7, COLOR_DK_GREEN);
     report->NewLine(2);
@@ -2318,17 +2286,14 @@ int System::DepositReport(Terminal *term, TimeInfo &start_time,
     report->TextL(GlobalTranslate("Sales by Category:"), COLOR_DK_GREEN);
     report->NewLine();
     for (int g = SALESGROUP_FOOD; g <= SALESGROUP_ROOM; ++g)
-	{
+    {
         if (s->IsGroupActive(g) || sales[g] != 0)
         {
-            report->TextL(SalesGroupName[g]);
-            report->TextPosR(-6, term->FormatPrice(sales[g]), col);
-            report->NewLine();
+            report->TextKV(SalesGroupName[g], term->FormatPrice(sales[g]), COLOR_DEFAULT, col);
         }
-	}
+    }
 
-    report->TextPosL(3, GlobalTranslate("Total Gross Sales"));
-    report->TextPosR(0, term->FormatPrice(total_sales), col);
+    report->TextKV(GlobalTranslate("Total Gross Sales"), term->FormatPrice(total_sales), COLOR_DEFAULT, col);
     report->UnderlinePosR(0, 7, col);
     report->NewLine(2);
 
@@ -2419,18 +2384,14 @@ int System::DepositReport(Terminal *term, TimeInfo &start_time,
     {
         if (mediacomp->name[0] != '\0' && (mediacomp->total != 0 || term->hide_zeros == 0))
         {
-            report->TextL(mediacomp->name);
-            report->TextPosR(-6, term->FormatPrice(mediacomp->total), col);
-            report->NewLine();
+            report->TextKV(mediacomp->name, term->FormatPrice(mediacomp->total), COLOR_DEFAULT, col);
         }
         mediacomp = mediacomp->next;
     }
 
     if (term->hide_zeros == 0 || item_comp != 0)
     {
-        report->TextL(GlobalTranslate("Line Item Comps"));
-        report->TextPosR(-6, term->FormatPrice(item_comp), col);
-        report->NewLine();
+        report->TextKV(GlobalTranslate("Line Item Comps"), term->FormatPrice(item_comp), COLOR_DEFAULT, col);
     }
 
     MediaList *mediameal = &meallist;
@@ -2438,9 +2399,7 @@ int System::DepositReport(Terminal *term, TimeInfo &start_time,
     {
         if (mediameal->name[0] != '\0' && (mediameal->total != 0 || term->hide_zeros == 0))
         {
-            report->TextL(mediameal->name);
-            report->TextPosR(-6, term->FormatPrice(mediameal->total), col);
-            report->NewLine();
+            report->TextKV(mediameal->name, term->FormatPrice(mediameal->total), COLOR_DEFAULT, col);
         }
         mediameal = mediameal->next;
     }
@@ -2450,9 +2409,7 @@ int System::DepositReport(Terminal *term, TimeInfo &start_time,
     {
         if (mediadiscount->name[0] != '\0' && (mediadiscount->total != 0 || term->hide_zeros == 0))
         {
-            report->TextL(mediadiscount->name);
-            report->TextPosR(-6, term->FormatPrice(mediadiscount->total), col);
-            report->NewLine();
+            report->TextKV(mediadiscount->name, term->FormatPrice(mediadiscount->total), COLOR_DEFAULT, col);
         }
         mediadiscount = mediadiscount->next;
     }
@@ -2462,9 +2419,7 @@ int System::DepositReport(Terminal *term, TimeInfo &start_time,
     {
         if (mediacoupon->name[0] != '\0' && (mediacoupon->total != 0 || term->hide_zeros == 0))
         {
-            report->TextL(mediacoupon->name);
-            report->TextPosR(-6, term->FormatPrice(mediacoupon->total), col);
-            report->NewLine();
+            report->TextKV(mediacoupon->name, term->FormatPrice(mediacoupon->total), COLOR_DEFAULT, col);
         }
         mediacoupon = mediacoupon->next;
     }
@@ -2606,9 +2561,7 @@ int System::DepositReport(Terminal *term, TimeInfo &start_time,
         {
             if (mediacredit->name[0] != '\0' && (mediacredit->total != 0 || term->hide_zeros == 0))
             {
-                report->TextL(mediacredit->name);
-                report->TextPosR(-6, term->FormatPrice(mediacredit->total), col);
-                report->NewLine();
+                report->TextKV(mediacredit->name, term->FormatPrice(mediacredit->total), COLOR_DEFAULT, col);
                 total_credit += mediacredit->total;
             }
             mediacredit = mediacredit->next;
@@ -2687,34 +2640,26 @@ int System::DepositReport(Terminal *term, TimeInfo &start_time,
     report->Mode(0);
     report->NewLine();
     
-    report->TextL(GlobalTranslate("Expected Balance"));
-    report->TextPosR(0, term->FormatPrice(book_balance), COLOR_DK_BLUE);
-    report->NewLine();
-    
-    report->TextL(GlobalTranslate("Actual Deposit"));
-    report->TextPosR(0, term->FormatPrice(actual_deposit), COLOR_DK_GREEN);
-    report->NewLine();
-    
+    report->TextKV(GlobalTranslate("Expected Balance"), term->FormatPrice(book_balance), COLOR_DEFAULT, COLOR_DK_BLUE);
+    report->TextKV(GlobalTranslate("Actual Deposit"), term->FormatPrice(actual_deposit), COLOR_DEFAULT, COLOR_DK_GREEN);
+
     if (reconciliation_diff != 0)
     {
         report->Mode(PRINT_BOLD);
         if (reconciliation_diff > 0)
         {
-            report->TextL(GlobalTranslate("Shortfall"));
-            report->TextPosR(0, term->FormatPrice(reconciliation_diff), COLOR_DK_RED);
+            report->TextKV(GlobalTranslate("Shortfall"), term->FormatPrice(reconciliation_diff), COLOR_DEFAULT, COLOR_DK_RED);
         }
         else
         {
-            report->TextL(GlobalTranslate("Overage"));
-            report->TextPosR(0, term->FormatPrice(-reconciliation_diff), COLOR_DK_GREEN);
+            report->TextKV(GlobalTranslate("Overage"), term->FormatPrice(-reconciliation_diff), COLOR_DEFAULT, COLOR_DK_GREEN);
         }
         report->Mode(0);
     }
     else
     {
         report->Mode(PRINT_BOLD);
-        report->TextL(GlobalTranslate("Balanced"));
-        report->TextPosR(0, term->FormatPrice(0), COLOR_DK_GREEN);
+        report->TextKV(GlobalTranslate("Balanced"), term->FormatPrice(0), COLOR_DEFAULT, COLOR_DK_GREEN);
         report->Mode(0);
     }
     report->NewLine(2);
@@ -2747,24 +2692,21 @@ int System::DepositReport(Terminal *term, TimeInfo &start_time,
     
     if (settings.authorize_method == CCAUTH_NONE)
     {
-        report->TextPosL(3, GlobalTranslate("Deposit Total"));
-        report->TextPosR(0, term->FormatPrice(cash + check + total_credit - tips_held), COLOR_DK_BLUE);
         report->Mode(PRINT_BOLD);
-        report->UnderlinePosR(0, 7, COLOR_DK_BLUE);
+        report->TextKV(GlobalTranslate("Deposit Total"), term->FormatPrice(cash + check + total_credit - tips_held), COLOR_DEFAULT, COLOR_DK_BLUE);
         report->Mode(0);
+        report->UnderlinePosR(0, 7, COLOR_DK_BLUE);
         report->NewLine(2);
     }
     else
     {
-        report->TextPosL(3, GlobalTranslate("Total Deposit: Cash, Checks"));
-        report->TextPosR(0, term->FormatPrice(cash + check - tips_held), COLOR_DK_BLUE);
+        report->TextKV(GlobalTranslate("Total Deposit: Cash, Checks"), term->FormatPrice(cash + check - tips_held), COLOR_DEFAULT, COLOR_DK_BLUE);
         report->Mode(PRINT_BOLD);
         report->UnderlinePosR(0, 7, COLOR_DK_BLUE);
         report->Mode(0);
         report->NewLine();
 
-        report->TextPosL(3, GlobalTranslate("Total Deposit: Debit/Credit"));
-        report->TextPosR(0, term->FormatPrice(total_credit), COLOR_DK_BLUE);
+        report->TextKV(GlobalTranslate("Total Deposit: Debit/Credit"), term->FormatPrice(total_credit), COLOR_DEFAULT, COLOR_DK_BLUE);
         report->Mode(PRINT_BOLD);
         report->UnderlinePosR(0, 7, COLOR_DK_BLUE);
         report->Mode(0);

--- a/main/ui/system_salesmix.cc
+++ b/main/ui/system_salesmix.cc
@@ -385,37 +385,32 @@ int FamilyItemReport(Terminal *t, ItemCount *branch,
             fi.initialized = true;
         }
         r.NewLine();
-        r.TextPosL(2, admission_filteredname(branch->name));  //here
         sales = branch->count * branch->cost;
         if (branch->type == ITEM_POUND)
         {
-            r.TextPosR(WEIGHT_POS, t->FormatPrice(branch->count));
+            r.TextKVMid(admission_filteredname(branch->name), t->FormatPrice(branch->count), t->FormatPrice(sales), WEIGHT_POS);
             fi.weight += branch->count;
             sales = sales / 100;
         }
         else
         {
-            r.NumberPosR(COUNT_POS, branch->count);
+            r.TextKVMid(admission_filteredname(branch->name), std::to_string(branch->count), t->FormatPrice(sales), COUNT_POS);
             fi.count += branch->count;
         }
-
-        r.TextPosR(0, t->FormatPrice(sales));
         fi.cost += sales;
 
         if (!branch->mods.empty() && t->GetSettings()->show_modifiers)
         {
-            for (const auto &entry : branch->mods.itemlist)
-            {
-                const ItemCount &modifier = entry.second;
-                modsales = modifier.cost * modifier.count;
-                // display the modifier name and count
-                r.NewLine();
-                r.TextPosL(5, modifier.name);
-                r.NumberPosR(COUNT_POS, modifier.count);
-                r.TextPosR(0, t->FormatPrice(modsales));
-                fi.count += modifier.count;
-                fi.cost += modsales;
-            }
+                for (const auto &entry : branch->mods.itemlist)
+                {
+                    const ItemCount &modifier = entry.second;
+                    modsales = modifier.cost * modifier.count;
+                    // display the modifier name and count
+                    r.NewLine();
+                    r.TextKVMid(modifier.name, std::to_string(modifier.count), t->FormatPrice(modsales), COUNT_POS);
+                    fi.count += modifier.count;
+                    fi.cost += modsales;
+                }
         }
     }
     
@@ -439,20 +434,18 @@ int NoFamilyItemReport(Terminal *t, ItemCount *branch, Report *r,
         NoFamilyItemReport(t, branch->left, r, total_count, total_cost, total_weight);
     
     r->NewLine();
-    r->TextPosL(0, admission_filteredname(branch->name)); //here
     sales = branch->count * branch->cost;
     if (branch->type == ITEM_POUND)
     {
-        r->TextPosR(WEIGHT_POS, t->FormatPrice(branch->count));
+        r->TextKVMid(admission_filteredname(branch->name), t->FormatPrice(branch->count), t->FormatPrice(sales), WEIGHT_POS);
         total_weight += branch->count;
         sales = sales / 100;
     }
     else
     {
-        r->NumberPosR(COUNT_POS, branch->count);
+        r->TextKVMid(admission_filteredname(branch->name), std::to_string(branch->count), t->FormatPrice(sales), COUNT_POS);
         total_count += branch->count;
     }
-    r->TextPosR(0, t->FormatPrice(sales));
     total_cost  += sales;
 
     if (!branch->mods.empty() && t->GetSettings()->show_modifiers)
@@ -463,9 +456,7 @@ int NoFamilyItemReport(Terminal *t, ItemCount *branch, Report *r,
             // display the modifier name and count
             modsales = modifier.cost * modifier.count;
             r->NewLine();
-            r->TextPosL(5, modifier.name);
-            r->NumberPosR(COUNT_POS, modifier.count);
-            r->TextPosR(0, t->FormatPrice(modsales));
+            r->TextKVMid(modifier.name, std::to_string(modifier.count), t->FormatPrice(modsales), COUNT_POS);
             total_cost += modsales;
             total_count += modifier.count;
         }
@@ -597,12 +588,10 @@ int System::SalesMixReport(Terminal *t, const TimeInfo &start_time, const TimeIn
                 r->Mode(PRINT_BOLD | PRINT_UNDERLINE);
                 str2 = FindStringByValue(i, FamilyValue, FamilyName, UnknownStr);
                 vt_safe_string::safe_format(str, STRLENGTH, "%s Total", MasterLocale->Translate(str2));
-                r->TextPosL(0, str, COLOR_DK_BLUE);
                 if (fi.count)
-                    r->NumberPosR(COUNT_POS, fi.count, COLOR_DK_BLUE);
+                    r->TextKVMid(str, std::to_string(fi.count), t->FormatPrice(fi.cost, 1), COUNT_POS, COLOR_DK_BLUE, COLOR_DK_BLUE, COLOR_DK_BLUE);
                 else
-                    r->TextPosR(WEIGHT_POS, t->FormatPrice(fi.weight), COLOR_DK_BLUE);
-                r->TextPosR(0, t->FormatPrice(fi.cost, 1), COLOR_DK_BLUE);
+                    r->TextKVMid(str, t->FormatPrice(fi.weight), t->FormatPrice(fi.cost, 1), WEIGHT_POS, COLOR_DK_BLUE, COLOR_DK_BLUE, COLOR_DK_BLUE);
                 r->Mode(0);
                 r->NewLine();
                 if (total_cost > 0)

--- a/zone/drawer_zone.cc
+++ b/zone/drawer_zone.cc
@@ -689,14 +689,13 @@ RenderResult DrawerManageZone::Render(Terminal *term, int update_flag)
                 int diff = dbentered - dbamount;
                 if (balance_count == media)
                     Background(term, yy - .5, 2.0, IMAGE_LIT_SAND);
-                TextL(term, yy, db->Description(s), COLOR_BLACK);
                 TextPosR(term, size_x - 17, yy, term->FormatPrice(dbamount), COLOR_BLACK);
                 pcolor = COLOR_BLACK;
                 if (diff < 0)
                     pcolor = COLOR_RED;
                 else if (diff > 0)
                     pcolor = COLOR_BLUE;
-                TextR(term, yy, term->FormatPrice(diff), pcolor);
+                TextLR(term, yy, db->Description(s), COLOR_BLACK, term->FormatPrice(diff), pcolor);
                 Entry(term, size_x - 16, yy, 7.5);
                 TextPosR(term, size_x - 8.5, yy, term->FormatPrice(dbentered), COLOR_YELLOW);
                 yy += 2;

--- a/zone/inventory_zone.cc
+++ b/zone/inventory_zone.cc
@@ -1503,8 +1503,7 @@ int ItemListZone::ListReport(Terminal *t, Report *r)
         
         Str iname;
         admission_parse_hash_name(iname, si->item_name);
-        r->TextL(iname.Value(), my_color);
-        r->TextR(t->FormatPrice(si->cost), my_color);
+        r->TextKV(iname.Value(), t->FormatPrice(si->cost), my_color, my_color);
         r->NewLine();
         si = si->next;
     }
@@ -1943,10 +1942,10 @@ int InvoiceZone::ListReport(Terminal *t, Report *r)
     {
         r->TextL(t->TimeDate(in->time, TD_DATE));
         Vendor *v = sys->inventory.FindVendorByID(in->vendor_id);
-        if (v)
-            r->TextC(v->name.Value());
-        else
-            r->TextC(GlobalTranslate("Unknown Vendor"));
+        if (v) {
+            r->TextKV(v->name.Value(), FormatPhoneNumber(v->phone));
+            r->NewLine();
+        }
         vt_safe_string::safe_format(str, 256, "%d", in->id);
         r->TextR(str);
         r->NewLine();

--- a/zone/order_zone.cc
+++ b/zone/order_zone.cc
@@ -210,34 +210,28 @@ RenderResult OrderEntryZone::Render(Terminal *t, int update_flag)
         TextR(t, 1, str, col);
         break;
     case CHECK_TAKEOUT:
-        TextL(t, 1, t->Translate("Take Out"), col);
         vt_safe_string::safe_format(str, 256, "%s %d of %d", t->Translate("Part"), sc->number, subs);
-        TextR(t, 1, str, col);
+        TextLR(t, 1, t->Translate("Take Out"), col, str, col);
         break;
     case CHECK_FASTFOOD:
-        TextL(t, 1, t->Translate("Fast Food"), col);
         vt_safe_string::safe_format(str, 256, "%s %d of %d", t->Translate("Part"), sc->number, subs);
-        TextR(t, 1, str, col);
+        TextLR(t, 1, t->Translate("Fast Food"), col, str, col);
         break;
     case CHECK_DELIVERY:
-        TextL(t, 1, t->Translate("Delivery"), col);
         vt_safe_string::safe_format(str, 256, "%s %d of %d", t->Translate("Part"), sc->number, subs);
-        TextR(t, 1, str, col);
+        TextLR(t, 1, t->Translate("Delivery"), col, str, col);
         break;
     case CHECK_RETAIL:
-        TextL(t, 1, t->Translate("Retail"), col);
         vt_safe_string::safe_format(str, 256, "%s %d of %d", t->Translate("Part"), sc->number, subs);
-        TextR(t, 1, str, col);
+        TextLR(t, 1, t->Translate("Retail"), col, str, col);
         break;
     case CHECK_TOGO:
-        TextL(t, 1, GlobalTranslate("To Go"), col);
         vt_safe_string::safe_format(str, 256, "%s %d of %d", t->Translate("Part"), sc->number, subs);
-        TextR(t, 1, str, col);
+        TextLR(t, 1, GlobalTranslate("To Go"), col, str, col);
         break;
     case CHECK_DINEIN:
-        TextL(t, 1, GlobalTranslate("Here"), col);
         vt_safe_string::safe_format(str, 256, "%s %d of %d", t->Translate("Part"), sc->number, subs);
-        TextR(t, 1, str, col);
+        TextLR(t, 1, GlobalTranslate("Here"), col, str, col);
         break;
 	}
 

--- a/zone/payment_zone.cc
+++ b/zone/payment_zone.cc
@@ -116,6 +116,7 @@ RenderResult PaymentZone::Render(Terminal *term, int update_flag)
         min_spacing = spacing;
 
     genericChar str[256];
+    genericChar lstr[256];
     // Header
     Flt line = 0.0;
     if (currCheck->IsTakeOut())
@@ -155,25 +156,37 @@ RenderResult PaymentZone::Render(Terminal *term, int update_flag)
     line += min_spacing * 1.5;
 
     int nameadd = 0;
+    int name_present = 0;
+    vt_safe_string::safe_copy(lstr, 256, "");
     if (strlen(currCheck->FirstName()) > 0)
     {
         if (strlen(currCheck->LastName()) > 0)
-            vt_safe_string::safe_format(str, 256, "%s %s", currCheck->FirstName(), currCheck->LastName());
+            vt_safe_string::safe_format(lstr, 256, "%s %s", currCheck->FirstName(), currCheck->LastName());
         else
-            vt_safe_string::safe_copy(str, 256, currCheck->FirstName());
-        TextL(term, line, str, text);
+            vt_safe_string::safe_copy(lstr, 256, currCheck->FirstName());
+        name_present = 1;
         nameadd = 1;
     }
     else if (strlen(currCheck->LastName()) > 0)
     {
-        TextL(term, line, currCheck->LastName(), text);
+        vt_safe_string::safe_copy(lstr, 256, currCheck->LastName());
+        name_present = 1;
         nameadd = 1;
     }
-    if (strlen(currCheck->PhoneNumber()) > 0)
+
+    if (name_present)
+    {
+        if (strlen(currCheck->PhoneNumber()) > 0)
+            TextLR(term, line, lstr, text, currCheck->PhoneNumber(), text);
+        else
+            TextL(term, line, lstr, text);
+    }
+    else if (strlen(currCheck->PhoneNumber()) > 0)
     {
         TextR(term, line, currCheck->PhoneNumber(), text);
         nameadd = 1;
     }
+
     if (nameadd > 0)
         line += min_spacing * 1.5;
 
@@ -335,8 +348,7 @@ RenderResult PaymentZone::Render(Terminal *term, int update_flag)
             // reset the total value to just the authed for the
             // subCheck->balance.
             payment->FigureTotals(1);
-            TextL(term, line, payment->Description(settings), c1);
-            TextR(term, line, term->FormatPrice(payment->value), c1);
+            TextLR(term, line, payment->Description(settings), c1, term->FormatPrice(payment->value), c1);
             payment->FigureTotals(0);
             Credit *cr = payment->credit;
             if (cr != nullptr)

--- a/zone/payout_zone.cc
+++ b/zone/payout_zone.cc
@@ -112,9 +112,8 @@ RenderResult PayoutZone::Render(Terminal *term, int update_flag)
     }
     else
     {
-        TextL(term, 2.3, term->Translate("Employee"), col);
+        TextLR(term, 2.3, term->Translate("Employee"), col, term->Translate("Amount Owed"), col);
         TextC(term, 2.3, term->Translate("Amount Paid"), col);
-        TextR(term, 2.3, term->Translate("Amount Owed"), col);
         report->selected_line = selected;
         report->Render(term, this, HEADER-1, 0, page, 0, spacing);
     }

--- a/zone/phrase_zone.cc
+++ b/zone/phrase_zone.cc
@@ -53,8 +53,7 @@ RenderResult PhraseZone::Render(Terminal *t, int update_flag)
     FnTrace("PhraseZone::Render()");
 
     FormZone::Render(t, update_flag);
-    TextL(t, 0, PageName[record_no], color[0]);
-    TextR(t, 0, t->PageNo(record_no + 1, PAGES), color[0]);
+    TextLR(t, 0, PageName[record_no], color[0], t->PageNo(record_no + 1, PAGES), color[0]);
     return RENDER_OKAY;
 }
 

--- a/zone/report_zone.cc
+++ b/zone/report_zone.cc
@@ -500,24 +500,12 @@ int ReportZone::ShowCheck(Terminal *term, Check *check)
     FnTrace("ReportZone::ShowCheck()");
     if (video_target == PRINTER_DEFAULT)
         return 1;  // always show everything on the default
-    Settings *settings = term->GetSettings();
-    int show = 0;
-    int vtarget;
-    Order *order;
-    SubCheck *scheck = check->SubList();
-    while (!show && (scheck != nullptr))
-    {
-        order = scheck->OrderList();
-        while (!show && (order != nullptr))
-        {
-            vtarget = order->VideoTarget(settings);
-            if (vtarget == video_target)
-                show = 1;
-            order = order->next;
-        }
-        scheck = scheck->next;
-    }
-    return show;
+    if (check == nullptr)
+        return 0;
+    // Use Check::PrintCount with ORDER_SHOWN to ensure there are actually
+    // printable (sent and not-yet-shown) orders for this video target.
+    int has_new_items = check->PrintCount(term, video_target, 0, ORDER_SHOWN);
+    return (has_new_items > 0) ? 1 : 0;
 }
 
 /****

--- a/zone/settings_zone.cc
+++ b/zone/settings_zone.cc
@@ -2277,13 +2277,11 @@ RenderResult TenderSetZone::Render(Terminal *term, int update_flag)
 		{
         default:
             TextC(term, 0, term->Translate("Customer Discounts"), col);
-            TextL(term, 2.3, term->Translate("Name"), col);
-            TextR(term, 2.3, term->Translate("Amount"), col);
+            TextLR(term, 2.3, term->Translate("Name"), col, term->Translate("Amount"), col);
             break;
         case 1:
             TextC(term, 0, term->Translate("Coupons"), col);
-            TextL(term, 2.3, term->Translate("Name"), col);
-            TextR(term, 2.3, term->Translate("Amount"), col);
+            TextLR(term, 2.3, term->Translate("Name"), col, term->Translate("Amount"), col);
             break;
         case 2:
             TextC(term, 0, term->Translate("Credit/Charge Cards"), col);
@@ -2295,8 +2293,7 @@ RenderResult TenderSetZone::Render(Terminal *term, int update_flag)
             break;
         case 4:
             TextC(term, 0, term->Translate("Employee Discounts"), col);
-            TextL(term, 2.3, term->Translate("Name"), col);
-            TextR(term, 2.3, term->Translate("Amount"), col);
+            TextLR(term, 2.3, term->Translate("Name"), col, term->Translate("Amount"), col);
             break;
 		}
 	}

--- a/zone/table_zone.cc
+++ b/zone/table_zone.cc
@@ -134,6 +134,7 @@ RenderResult RoomDialog::Render(Terminal *term, int update_flag)
     int total = 0;
     int balance = 0;
     genericChar str[256];
+    genericChar rstr[256];
     int no = 0;
     Check *check = term->check;
     if (check)
@@ -153,9 +154,8 @@ RenderResult RoomDialog::Render(Terminal *term, int update_flag)
         TextC(term, 0, str);
     else
     {
-        TextL(term, 0, str);
-        vt_safe_string::safe_format(str, 256, "%s %06d", term->Translate("Folio No"), no);
-        TextR(term, 0, str);
+        vt_safe_string::safe_format(rstr, 256, "%s %06d", term->Translate("Folio No"), no);
+        TextLR(term, 0, str, COLOR_DEFAULT, rstr, COLOR_DEFAULT);
     }
 
     (void)checkout->SetRegion(x + w - border - 140, y + border + 46, 140, 110);  // Suppress nodiscard warning

--- a/zone/user_edit_zone.cc
+++ b/zone/user_edit_zone.cc
@@ -126,9 +126,8 @@ RenderResult UserEditZone::Render(Terminal *term, int update_flag)
         }
 
         TextC(term, 0, term->Translate(str), col);
-        TextL(term, 1.3, term->Translate("Employee Name"), col);
+        TextLR(term, 1.3, term->Translate("Employee Name"), col, term->Translate("Phone Number"), col);
         TextC(term, 1.3, term->Translate("Job Title"), col);
-        TextR(term, 1.3, term->Translate("Phone Number"), col);
     }
     else
     {


### PR DESCRIPTION
**Description**
- **Summary:** This PR combines the last two commits on branch `master`. It updates the changelog and fixes blank kitchen/bar video checks in `ReportZone::ShowCheck`.
- **Commits included:**
  - **`7516740`**: chore(changelog): document Report/UI helpers, Deposit report redesign, and zone refactors (2026-04-14)  
    - **Author:** Ariel Brambila Pelayo — 2026-04-14 22:37:08 -0700  
    - **Changed files:** changelog.md, check.cc, employee.cc, drawer.cc, report.cc, report.hh, system_report.cc, system_salesmix.cc, drawer_zone.cc, inventory_zone.cc, order_zone.cc, payment_zone.cc, payout_zone.cc, phrase_zone.cc, settings_zone.cc, table_zone.cc, user_edit_zone.cc
  - **`3ffc070`**: Fix: prevent blank kitchen/bar video checks (ReportZone::ShowCheck uses PrintCount)  
    - **Author:** Ariel Brambila Pelayo — 2026-04-14 20:05:25 -0700  
    - **Changed files:** changelog.md, report_zone.cc