### PR TITLE
Index Tab selected feedback, no-op guard, page-zero block, and auto-page creation

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+### Added
+- **Index Tab Buttons: Selected visual feedback, no-op guard, page-zero block, and auto-page creation** (2026-05-28)
+  - `IndexTabZone::State()` now returns the selected state (1) whenever the terminal's current page matches the tab's `jump_id`. The tab for the active page is automatically rendered with its configured selected-state edge, texture, and font color (`frame[1]`, `texture[1]`, `color[1]`) — no new `Terminal` fields required.
+  - `IndexTabZone::Touch()` returns `SIGNAL_IGNORED` when the terminal is already on the tab's target page, preventing a redundant page jump.
+  - `ZoneDB::Add(Page*)` now rejects any page with `id == 0`, reporting an error. This is enforced at the single authoritative insertion point so no page with number zero can be created through any code path.
+  - `ZoneDB::NextAvailablePageID(int start_id, int page_size)` helper added — returns the first unused page ID ≥ `start_id` for the given screen size.
+  - When a **brand-new** `ZONE_INDEX_TAB` button is saved (via `Terminal::ReadZone()`), and it has no jump target yet (`JUMP_NONE`), a new `PAGE_ITEM` menu page is automatically created using the button's name, assigned the first available ID ≥ 60, and the button is set to `JUMP_NORMAL` pointing to that page. Editing an existing Index Tab with an already-configured jump is unaffected.
+  - Files modified: `zone/button_zone.hh`, `zone/button_zone.cc`, `zone/zone.hh`, `zone/zone.cc`, `main/hardware/terminal.cc`.
+
 ### Work In Progress
 - **Allow Multiple Terminal Logins (experimental)** (2026-04-12)
   - Added a persisted soft-switch `allow_multi_login` (bumped `SETTINGS_VERSION` to 107) which allows the same `Employee` to be logged into multiple terminals when enabled.

--- a/main/hardware/terminal.cc
+++ b/main/hardware/terminal.cc
@@ -5947,6 +5947,28 @@ int Terminal::ReadZone()
         edit_zone = nullptr;
     }
 
+    // Auto-create a menu page for a brand-new Index Tab button that has no jump target yet
+    if (newZone->Type() == ZONE_INDEX_TAB &&
+        edit_zone == nullptr &&
+        newZone->JumpType() && *newZone->JumpType() == JUMP_NONE &&
+        newZone->name.size() > 0)
+    {
+        int new_page_id = zone_db->NextAvailablePageID(60, page_size);
+        Page *autoPage  = NewPosPage();
+        if (autoPage != nullptr)
+        {
+            autoPage->id    = new_page_id;
+            autoPage->size  = page_size;
+            autoPage->type  = PAGE_ITEM;
+            autoPage->index = INDEX_GENERAL;
+            autoPage->name.Set(newZone->name.Value());
+            autoPage->Init(zone_db);
+            zone_db->Add(autoPage);
+            *newZone->JumpType() = JUMP_NORMAL;
+            *newZone->JumpID()   = new_page_id;
+        }
+    }
+
     if (newZone->Type() == ZONE_COMMENT)
         currPage->AddFront(newZone); // make sure comment zones are always on top
     else

--- a/zone/button_zone.cc
+++ b/zone/button_zone.cc
@@ -1156,6 +1156,26 @@ int IndexTabZone::CanEdit(Terminal *t)
     return 0;
 }
 
+int IndexTabZone::State(Terminal *t)
+{
+    FnTrace("IndexTabZone::State()");
+    if (active == 0)
+        return 2;  // disabled
+    // Show selected appearance when the terminal is currently on this tab's target page
+    if (jump_id != 0 && t->page != nullptr && t->page->id == jump_id)
+        return 1;
+    return stay_lit;  // normal (0) or stay-lit
+}
+
+SignalResult IndexTabZone::Touch(Terminal *term, int tx, int ty)
+{
+    FnTrace("IndexTabZone::Touch()");
+    // Already on this tab's target page — nothing to do
+    if (jump_id != 0 && term->page != nullptr && term->page->id == jump_id)
+        return SIGNAL_IGNORED;
+    return ButtonZone::Touch(term, tx, ty);
+}
+
 // LanguageButtonZone implementation
 
 LanguageButtonZone::LanguageButtonZone()

--- a/zone/button_zone.hh
+++ b/zone/button_zone.hh
@@ -197,7 +197,11 @@ public:
     int          CanSelect(Terminal *t) override;
     int          CanEdit(Terminal *t) override;
     std::unique_ptr<Zone> Copy() override;
-    int  GainFocus(Terminal *term, Zone *oldfocus) override { return 0; }
+    int          GainFocus(Terminal *term, Zone *oldfocus) override { return 0; }
+    // Returns selected-state (1) when the terminal is currently on this tab's target page
+    int          State(Terminal *t) override;
+    // No-op when already on this tab's target page; otherwise delegates to ButtonZone
+    SignalResult Touch(Terminal *term, int tx, int ty) override;
 };
 
 class LanguageButtonZone : public ButtonZone

--- a/zone/zone.cc
+++ b/zone/zone.cc
@@ -1580,6 +1580,12 @@ int ZoneDB::Add(Page *p)
     if (p == nullptr)
         return 1;
 
+    if (p->id == 0)
+    {
+        ReportError("Page number 0 is not allowed");
+        return 1;
+    }
+
     // start at end of list and work backwords
     Page *ptr = page_list.Tail();
     while (ptr && (p->id < ptr->id || (p->id == ptr->id && p->size > ptr->size)))
@@ -1587,6 +1593,15 @@ int ZoneDB::Add(Page *p)
 
     // Insert p after ptr
     return page_list.AddAfterNode(ptr, p);
+}
+
+int ZoneDB::NextAvailablePageID(int start_id, int page_size)
+{
+    FnTrace("ZoneDB::NextAvailablePageID()");
+    int id = (start_id > 0) ? start_id : 1;
+    while (FindByID(id, page_size) != nullptr)
+        ++id;
+    return id;
 }
 
 int ZoneDB::AddUnique(Page *page)

--- a/zone/zone.hh
+++ b/zone/zone.hh
@@ -388,6 +388,8 @@ public:
 
     int ValidateSystemPages();  // Check for System Pages with invalid parent_id values
     int PrintZoneDB(const char* dest = nullptr, int brief = 0);  // for debugging only
+    // Returns the first page ID >= start_id that is not already in use for the given size
+    int NextAvailablePageID(int start_id, int page_size);
 };
 
 #endif


### PR DESCRIPTION
**Description:**

This PR implements three quality-of-life improvements to Index Tab buttons that together make it dramatically easier to build and navigate multi-page interfaces.

---

### What changed

#### Visual feedback — active tab highlights automatically
`IndexTabZone::State()` is overridden to return the selected state (`1`) whenever the terminal's current page matches the tab's `jump_id`. Because `Zone::Draw()` already uses the `State()` result to pick `frame[state]`, `texture[state]`, and `color[state]`, the tab for the page you're on renders automatically in its configured _selected_ appearance (edge, texture, font color). No new fields on `Terminal` are needed.

#### No-op guard — tapping your current tab does nothing
`IndexTabZone::Touch()` returns `SIGNAL_IGNORED` when the terminal is already on the tab's target page. This prevents a pointless re-jump and a screen flash when a user taps the tab for the page they're already viewing.

#### Block page number zero
`ZoneDB::Add(Page*)` — the single authoritative insertion point for all pages — now rejects any page with `id == 0` with a `ReportError`. No page numbered zero can be created through any code path.

#### Auto-create a menu page when a new Index Tab button is saved
`ZoneDB::NextAvailablePageID(int start_id, int page_size)` is a new helper that walks up from `start_id` until it finds an unused page ID.

In `Terminal::ReadZone()`, when a **brand-new** `ZONE_INDEX_TAB` is saved with no jump target yet (`JUMP_NONE`), the system automatically:
1. Finds the first available page ID ≥ 60.
2. Creates a `PAGE_ITEM` menu page named after the button.
3. Registers it in the zone database.
4. Sets the button's jump to `JUMP_NORMAL` targeting the new page.

Editing an existing Index Tab that already has a configured jump is completely unaffected.

---

### Files changed
| File | Change |
|---|---|
| button_zone.hh | Add `State()` and `Touch()` overrides to `IndexTabZone` |
| button_zone.cc | Implement both overrides |
| zone.hh | Declare `ZoneDB::NextAvailablePageID()` |
| zone.cc | Page-zero guard in `ZoneDB::Add()`; implement `NextAvailablePageID()` |
| terminal.cc | Auto-page-creation block in `Terminal::ReadZone()` |
| changelog.md | Entry under `[Unreleased] → Added` |

**6 files changed, 73 insertions(+), 1 deletion(-)**