### PR TITLE
dialog: remove redundant "Menu Type" field from Button Properties Dialog

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+### Removed
+- **Button Properties Dialog: Remove redundant "Menu Type" field** (2026-05-28)
+  - The "Menu Type" selector (`item_type` `DialogMenu` widget in `ZoneDialog`) was redundant with the more specific zone types already present in "Button's Type" (`ZONE_ITEM_NORMAL`, `ZONE_ITEM_MODIFIER`, `ZONE_ITEM_METHOD`, `ZONE_ITEM_SUBSTITUTE`, `ZONE_ITEM_POUND`, `ZONE_ITEM_ADMISSION`). The item classification (`itype`) is now derived entirely from the selected zone type; for the legacy generic `ZONE_ITEM` type the classification defaults to `ITEM_NORMAL`. The network protocol byte is preserved unchanged.
+  - Files modified: `term/term_dialog.hh`, `term/term_dialog.cc`.
+
 ### Added
 - **Index Tab Buttons: Selected visual feedback, no-op guard, page-zero block, and auto-page creation** (2026-05-28)
   - `IndexTabZone::State()` now returns the selected state (1) whenever the terminal's current page matches the tab's `jump_id`. The tab for the active page is automatically rendered with its configured selected-state edge, texture, and font color (`frame[1]`, `texture[1]`, `color[1]`) — no new `Terminal` fields required.

--- a/term/term_dialog.cc
+++ b/term/term_dialog.cc
@@ -1014,7 +1014,7 @@ void EZ_TypeCB(Widget widget, XtPointer client_data, XtPointer call_data)
     else if (ztype == ZONE_ITEM_SUBSTITUTE) itype = ITEM_SUBSTITUTE;
     else if (ztype == ZONE_ITEM_POUND) itype = ITEM_POUND;
     else if (ztype == ZONE_ITEM_ADMISSION) itype = ITEM_ADMISSION;
-    else itype = d->item_type.Value(); // For ZONE_ITEM, get from selector
+    else itype = ITEM_NORMAL; // For generic ZONE_ITEM, default to normal
 
     if (ztype == d->ztype && itype == d->itype)
         return;
@@ -1115,8 +1115,6 @@ ZoneDialog::ZoneDialog(Widget parent)
     item_name.Init(container, "This Button's True Name");
     item_zone_name.Init(container, "This Button's On-Screen Name, if Different than its True Name");
     item_print_name.Init(container, "This Button's Abbreviation for Remote Printing if Different than its True Name");
-    item_type.Init(container, "Menu Type", ItemTypeName, ItemTypeValue,
-                   reinterpret_cast<void*>(EZ_TypeCB), this);
     item_location.Init(container,"Event Location");
     item_event_time.Init(container, "Event Time");
     item_total_tickets.Init(container,"Total Seats");
@@ -1244,7 +1242,6 @@ int ZoneDialog::Open()
     item_print_name.Set(RStr());
     item_zone_name.Set(RStr());
     itype = RInt8();
-    item_type.Set(itype);
     item_location.Set(RStr());
     item_event_time.Set(RStr());
     item_total_tickets.Set(RStr());
@@ -1304,7 +1301,6 @@ int ZoneDialog::Correct()
     item_name.Show(IsItemZoneType(t));
     item_zone_name.Show(IsItemZoneType(t));
     item_print_name.Show(IsItemZoneType(t));
-    item_type.Show(t == ZONE_ITEM); // Only show item type selector for generic ZONE_ITEM
     // For new specific item zone types, derive itype from zone type
     if (t == ZONE_ITEM_NORMAL) itype = ITEM_NORMAL;
     else if (t == ZONE_ITEM_MODIFIER) itype = ITEM_MODIFIER;
@@ -1447,7 +1443,7 @@ int ZoneDialog::Send()
     WInt16(customer_type.Value());
     WInt8(drawer_zone_type.Value());
 
-    if(item_type.Value() == ITEM_ADMISSION)
+    if(itype == ITEM_ADMISSION)
     {
 	Str h_itemname,h_time,h_location,h_priceclass,hout;
 	h_itemname.Set(item_name.Value());
@@ -1464,7 +1460,7 @@ int ZoneDialog::Send()
     }
     WStr(item_print_name.Value());
     WStr(item_zone_name.Value());
-    WInt8(item_type.Value());
+    WInt8(itype);
     WStr(item_location.Value());
     WStr(item_event_time.Value());
     WStr(item_total_tickets.Value());

--- a/term/term_dialog.hh
+++ b/term/term_dialog.hh
@@ -166,7 +166,6 @@ public:
     DialogMenu  color3;
     DialogMenu  shape;
     DialogMenu  shadow;
-    DialogMenu  item_type;
     DialogMenu  item_family;
     DialogMenu  item_sales;
     DialogMenu  item_printer;


### PR DESCRIPTION
## Summary

The "Menu Type" selector in the Button Properties Dialog was redundant.
"Button's Type" already has a dedicated entry for every menu-item
sub-classification:

| Button's Type         | Equivalent Menu Type |
|-----------------------|----------------------|
| Menu Item (Normal)    | Normal               |
| Menu Item (Modifier)  | Modifier             |
| Menu Item (Method)    | Method               |
| Menu Item (Substitute)| Substitute           |
| Menu Item (Pound)     | Pound                |
| Menu Item (Admission) | Admission            |

When any of those specific types were selected, the dialog already
auto-derived `itype` from `ztype` and hid the Menu Type widget anyway.
The widget was only visible for the legacy generic `ZONE_ITEM` type.

## Changes

- Removed the `item_type` (`DialogMenu`) widget from `ZoneDialog`.
- `itype` is now derived solely from `ztype` in `EZ_TypeCB` and
  `Correct()`. The generic `ZONE_ITEM` type defaults to `ITEM_NORMAL`.
- The network protocol byte (`WInt8(itype)`) is **unchanged** — the
  server still sends and receives the same 1-byte item-type value.

## Files Modified

- `term/term_dialog.hh` — removed `item_type` field from `ZoneDialog`
- `term/term_dialog.cc` — removed widget creation, `Set`, `Show`, and
  two `item_type.Value()` call sites; replaced with `itype`